### PR TITLE
Add configurable render frame-rate cap (maxFps)

### DIFF
--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -64,6 +64,9 @@ export interface Config {
   staleSec: number;
   /** Ease factor toward each fresh fix (0 = snap, 1 = never move). */
   smoothing: number;
+  /** Cap the render loop, frames per second. 0 = uncapped (use display
+   *  refresh rate). Lower this to cut GPU/CPU load (and laptop fan noise). */
+  maxFps: number;
 
   // --- visuals ---
   theme: Theme;
@@ -127,6 +130,7 @@ export const DEFAULT_CONFIG: Config = {
   maxExtrapolationSec: 5,
   staleSec: 20,
   smoothing: 0.18,
+  maxFps: 0,
 
   theme: "ambient",
   palette: {

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -179,7 +179,7 @@ export function Control() {
             <Slider value={cfg.staleSec} min={5} max={60} step={1} unit="s"
               onChange={(v) => set({ staleSec: v })} />
           </Row>
-          <Row label="Max FPS" hint="0 = uncapped · lower cuts fan/CPU">
+          <Row label="Max FPS" hint="0 = uncapped">
             <Slider value={cfg.maxFps} min={0} max={120} step={5} unit="fps"
               onChange={(v) => set({ maxFps: v })} />
           </Row>

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -179,6 +179,10 @@ export function Control() {
             <Slider value={cfg.staleSec} min={5} max={60} step={1} unit="s"
               onChange={(v) => set({ staleSec: v })} />
           </Row>
+          <Row label="Max FPS" hint="0 = uncapped · lower cuts fan/CPU">
+            <Slider value={cfg.maxFps} min={0} max={120} step={5} unit="fps"
+              onChange={(v) => set({ maxFps: v })} />
+          </Row>
         </Section>
 
         <Section title="Overlays">

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -99,8 +99,9 @@ export class Renderer {
   private w = 0;
   private h = 0;
   private prevFrame = 0;
-  /** Timestamp of the last drawn frame, for the maxFps cap. */
-  private lastDraw = 0;
+  /** When the next frame is due (ms, rAF clock), for the maxFps cap.
+   *  0 = uninitialized; set on the first capped frame. */
+  private nextFrameDue = 0;
   /** Current frame time in seconds, for animating props/rotors. */
   private frameT = 0;
 
@@ -125,14 +126,21 @@ export class Renderer {
     setInterval(() => void this.fetchTles(), 3600_000);
     const loop = (now: number) => {
       this.raf = requestAnimationFrame(loop);
-      // Cap to maxFps: skip this rAF tick if we're ahead of the frame budget.
-      // 0 (or less) means uncapped — draw every rAF tick.
+      // Cap to maxFps via an accumulator: advance a running "due" time by whole
+      // frame intervals so the cadence stays anchored to a schedule (even
+      // pacing, no drift) rather than to actual draw timestamps. fps <= 0 means
+      // uncapped — draw on every rAF tick.
       const fps = this.getConfig().maxFps;
       if (fps > 0) {
-        const minInterval = 1000 / fps;
-        // Small slack so we don't perpetually miss the target by a hair.
-        if (now - this.lastDraw < minInterval - 1) return;
-        this.lastDraw = now;
+        const interval = 1000 / fps;
+        if (this.nextFrameDue === 0) this.nextFrameDue = now;
+        if (now < this.nextFrameDue) return; // not due yet — skip this tick
+        this.nextFrameDue += interval;
+        // If we've fallen more than a frame behind (e.g. tab was backgrounded
+        // or a draw stalled), resync to avoid a burst of catch-up frames.
+        if (now - this.nextFrameDue > interval) this.nextFrameDue = now + interval;
+      } else {
+        this.nextFrameDue = 0; // reset so re-enabling the cap starts clean
       }
       this.draw();
     };

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -99,6 +99,8 @@ export class Renderer {
   private w = 0;
   private h = 0;
   private prevFrame = 0;
+  /** Timestamp of the last drawn frame, for the maxFps cap. */
+  private lastDraw = 0;
   /** Current frame time in seconds, for animating props/rotors. */
   private frameT = 0;
 
@@ -121,9 +123,18 @@ export class Renderer {
   start(): void {
     void this.fetchTles();
     setInterval(() => void this.fetchTles(), 3600_000);
-    const loop = () => {
-      this.draw();
+    const loop = (now: number) => {
       this.raf = requestAnimationFrame(loop);
+      // Cap to maxFps: skip this rAF tick if we're ahead of the frame budget.
+      // 0 (or less) means uncapped — draw every rAF tick.
+      const fps = this.getConfig().maxFps;
+      if (fps > 0) {
+        const minInterval = 1000 / fps;
+        // Small slack so we don't perpetually miss the target by a hair.
+        if (now - this.lastDraw < minInterval - 1) return;
+        this.lastDraw = now;
+      }
+      this.draw();
     };
     this.raf = requestAnimationFrame(loop);
   }


### PR DESCRIPTION
👋 First off — thanks for Skylight, it's a delightful project. I didn't see a `CONTRIBUTING` guide, so I hope an unsolicited PR is welcome; happy to adjust scope, style, or anything else to match how you'd prefer contributions.

## What
Adds a `maxFps` config field that throttles the display render loop, surfaced as a **Max FPS** slider in the control panel's Motion section.

## Why
The display renders on an **uncapped `requestAnimationFrame`**, repainting the full canvas at the monitor's refresh rate (60–144 Hz) continuously. Because the scene is always animating (twinkling stars, rotors, comet trails), no frames can be skipped as unchanged — so GPU/CPU stays pinned. On a laptop used for dev/testing this is very audible as fan noise.

Quick profiling pointed entirely at client-side rendering (the Node backend sits near-idle), so capping the frame rate is the direct lever. On the Pi-to-projector setup this won't matter, but it makes local development much quieter.

## How
- Accumulator-based pacing: the loop is still driven by `requestAnimationFrame` (so it still pauses on hidden tabs and stays vsync-aligned) and advances a running "due" time by whole frame intervals, skipping ticks that arrive early. It resyncs if it falls more than a frame behind (backgrounded tab / stalled draw) to avoid a catch-up burst.
- `maxFps` is read live each frame, so changes from the control panel apply instantly.
- Animation timing is unaffected: `frameDt` is derived from actual draw deltas, so time-based motion runs at the same wall-clock speed whether capped or not.

## Compatibility
Default is **`0` (uncapped)** — preserves current behavior exactly. Purely opt-in.

## Known limitation
Frame-skipping can only yield refresh-rate ÷ an integer, so a cap that doesn't evenly divide the panel's refresh rate (e.g. 30 fps on a 144 Hz display) will have slightly uneven pacing. The accumulator keeps it as even as possible; for perfectly smooth motion, pick a divisor of your refresh rate (e.g. 30 on 60 Hz). Happy to add a doc note if you'd like.

## Test plan
- `pnpm typecheck` passes.
- Control panel → Motion → Max FPS = 30 → render cadence halves on a 60 Hz panel, motion stays smooth (client interpolation), measured CPU/fan drops noticeably.
- Max FPS = 0 → uncapped, identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)