### PR TITLE
feat: make dump1090 radio URL configurable at runtime

### DIFF
--- a/server/src/config-store.ts
+++ b/server/src/config-store.ts
@@ -6,20 +6,54 @@ import { dirname } from "node:path";
 import { DEFAULT_CONFIG, mergeConfig, type Config } from "@shared/index.js";
 
 type Listener = (config: Config) => void;
+const RADIO_URL_ERROR = "radioUrl must be an http or https URL";
+
+export class ConfigValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigValidationError";
+  }
+}
+
+function validateRadioUrl(radioUrl: unknown): void {
+  if (typeof radioUrl !== "string") {
+    throw new ConfigValidationError(RADIO_URL_ERROR);
+  }
+
+  try {
+    const { protocol } = new URL(radioUrl);
+    if (protocol === "http:" || protocol === "https:") return;
+  } catch {
+    // Fall through to the common validation error.
+  }
+
+  throw new ConfigValidationError(RADIO_URL_ERROR);
+}
+
+function validateConfigWrite(config: Partial<Config>): void {
+  if (config && Object.prototype.hasOwnProperty.call(config, "radioUrl")) {
+    validateRadioUrl(config.radioUrl);
+  }
+}
 
 export class ConfigStore {
-  private config: Config = DEFAULT_CONFIG;
+  private config: Config;
   private listeners = new Set<Listener>();
   private saveTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(private path: string) {}
+  constructor(
+    private path: string,
+    private defaults: Config = DEFAULT_CONFIG,
+  ) {
+    this.config = defaults;
+  }
 
   async load(): Promise<void> {
     try {
       const raw = await readFile(this.path, "utf8");
-      this.config = mergeConfig(DEFAULT_CONFIG, JSON.parse(raw) as Partial<Config>);
+      this.config = mergeConfig(this.defaults, JSON.parse(raw) as Partial<Config>);
     } catch {
-      this.config = DEFAULT_CONFIG; // first run
+      this.config = this.defaults; // first run
     }
   }
 
@@ -28,6 +62,7 @@ export class ConfigStore {
   }
 
   patch(patch: Partial<Config>): Config {
+    validateConfigWrite(patch);
     this.config = mergeConfig(this.config, patch);
     this.emit();
     this.scheduleSave();
@@ -35,14 +70,15 @@ export class ConfigStore {
   }
 
   set(config: Config): Config {
-    this.config = mergeConfig(DEFAULT_CONFIG, config);
+    validateConfigWrite(config);
+    this.config = mergeConfig(this.defaults, config);
     this.emit();
     this.scheduleSave();
     return this.config;
   }
 
   reset(): Config {
-    this.config = DEFAULT_CONFIG;
+    this.config = this.defaults;
     this.emit();
     this.scheduleSave();
     return this.config;

--- a/server/src/datasource.ts
+++ b/server/src/datasource.ts
@@ -161,7 +161,7 @@ export class Poller {
 
   private async fetchList(source: DataSource, now: number): Promise<Aircraft[] | null> {
     try {
-      const url = source === "radio" ? this.o.radioUrl : this.buildApiUrl();
+      const url = source === "radio" ? this.o.getConfig().radioUrl : this.buildApiUrl();
       const json = await fetchJson(url);
       const rawList: RawAircraft[] = json.aircraft ?? json.ac ?? [];
       const list: Aircraft[] = [];

--- a/server/src/hub.ts
+++ b/server/src/hub.ts
@@ -10,7 +10,7 @@ import type {
   Aircraft,
   SourceStatus,
 } from "@shared/index.js";
-import type { ConfigStore } from "./config-store.js";
+import { ConfigValidationError, type ConfigStore } from "./config-store.js";
 
 export interface HubDeps {
   store: ConfigStore;
@@ -39,12 +39,12 @@ export class Hub {
     this.send(ws, { type: "aircraft", now: snap.now, aircraft: snap.aircraft });
     this.send(ws, { type: "status", status: this.deps.getStatus() });
 
-    ws.on("message", (raw) => this.onMessage(raw.toString()));
+    ws.on("message", (raw) => this.onMessage(ws, raw.toString()));
     ws.on("close", () => this.clients.delete(ws));
     ws.on("error", () => this.clients.delete(ws));
   }
 
-  private onMessage(raw: string): void {
+  private onMessage(ws: WebSocket, raw: string): void {
     let msg: ClientMessage;
     try {
       msg = JSON.parse(raw) as ClientMessage;
@@ -53,10 +53,10 @@ export class Hub {
     }
     switch (msg.type) {
       case "patchConfig":
-        this.deps.store.patch(msg.patch); // store.subscribe broadcasts
+        this.writeConfig(ws, () => this.deps.store.patch(msg.patch)); // store.subscribe broadcasts
         break;
       case "setConfig":
-        this.deps.store.set(msg.config);
+        this.writeConfig(ws, () => this.deps.store.set(msg.config));
         break;
       case "resetConfig":
         this.deps.store.reset();
@@ -74,6 +74,18 @@ export class Hub {
   }
   broadcastConfig(config: Config): void {
     this.broadcast({ type: "config", config });
+  }
+
+  private writeConfig(ws: WebSocket, write: () => void): void {
+    try {
+      write();
+    } catch (err) {
+      if (err instanceof ConfigValidationError) {
+        this.send(ws, { type: "config", config: this.deps.store.get() });
+        return;
+      }
+      throw err;
+    }
   }
 
   private broadcast(msg: ServerMessage): void {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,10 +5,10 @@
 import { createServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import express from "express";
-import type { DataSource } from "@shared/index.js";
-import { ConfigStore } from "./config-store.js";
+import { DEFAULT_CONFIG, type Config, type DataSource } from "@shared/index.js";
+import { ConfigStore, ConfigValidationError } from "./config-store.js";
 import { RouteEnricher } from "./enrich/routes.js";
 import { Poller } from "./datasource.js";
 import { Hub } from "./hub.js";
@@ -30,10 +30,25 @@ const ROUTE_CACHE_HOURS = Number(process.env.ROUTE_CACHE_HOURS ?? 12);
 // When on radio, also poll the API and merge (keeps landing aircraft alive).
 const SUPPLEMENT_API = (process.env.SUPPLEMENT_API ?? "1") !== "0";
 const API_POLL_MS = Number(process.env.API_POLL_MS ?? 4000);
+const CONFIG_PATH = resolve(DATA_DIR, "config.json");
+const SERVER_DEFAULT_CONFIG: Config = { ...DEFAULT_CONFIG, radioUrl: RADIO_URL };
+
+function hasPersistedRadioUrl(path: string): boolean {
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<Config>;
+    return typeof raw.radioUrl === "string";
+  } catch {
+    return false;
+  }
+}
 
 async function main(): Promise<void> {
-  const store = new ConfigStore(resolve(DATA_DIR, "config.json"));
+  const configHasRadioUrl = hasPersistedRadioUrl(CONFIG_PATH);
+  const store = new ConfigStore(CONFIG_PATH, SERVER_DEFAULT_CONFIG);
   await store.load();
+  if (!configHasRadioUrl && store.get().radioUrl !== RADIO_URL) {
+    store.patch({ radioUrl: RADIO_URL });
+  }
 
   const enricher = new RouteEnricher(
     resolve(DATA_DIR, "route-cache.json"),
@@ -70,7 +85,16 @@ async function main(): Promise<void> {
   // --- REST API (handy for debugging + non-WS clients) ---
   app.get("/api/health", (_req, res) => res.json({ ok: true }));
   app.get("/api/config", (_req, res) => res.json(store.get()));
-  app.post("/api/config", (req, res) => res.json(store.patch(req.body)));
+  app.post("/api/config", (req, res) => {
+    try {
+      res.json(store.patch(req.body));
+    } catch (err) {
+      if (err instanceof ConfigValidationError) {
+        return res.status(400).json({ error: err.message });
+      }
+      throw err;
+    }
+  });
   app.post("/api/config/reset", (_req, res) => res.json(store.reset()));
   app.get("/api/aircraft", (_req, res) => res.json(poller.getSnapshot()));
   app.get("/api/status", (_req, res) => res.json(poller.getStatus()));

--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -41,6 +41,10 @@ export interface Config {
   centerLon: number;
   radiusMiles: number;
 
+  // --- data source ---
+  /** dump1090/readsb aircraft.json URL for the radio source. */
+  radioUrl: string;
+
   // --- calibration (tune against a real overhead pass) ---
   /** Rotate the whole field, degrees. */
   rotationDeg: number;
@@ -116,6 +120,8 @@ export const DEFAULT_CONFIG: Config = {
   centerLat: 37.6213,
   centerLon: -122.379,
   radiusMiles: 3,
+
+  radioUrl: "http://localhost:8080/data/aircraft.json",
 
   rotationDeg: 0,
   mirrorX: true,

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -30,6 +30,7 @@ const FIELD_LABELS: Record<keyof ShowFields, string> = {
 export function Control() {
   const { state, conn } = useStream("control");
   const cfg = state.config;
+  const [radioUrl, setRadioUrl] = useState("");
 
   // ISS pass finder (for the Sky section).
   const [tles, setTles] = useState<Tle[]>([]);
@@ -43,6 +44,9 @@ export function Control() {
       on = false;
     };
   }, []);
+  useEffect(() => {
+    if (cfg) setRadioUrl(cfg.radioUrl);
+  }, [cfg]);
   const nextPass = useMemo(
     () => (tles.length && cfg ? nextISSPass(Date.now(), cfg.centerLat, cfg.centerLon, tles) : null),
     [tles, cfg?.centerLat, cfg?.centerLon],
@@ -58,8 +62,14 @@ export function Control() {
   }
 
   const set = (patch: Partial<Config>) => conn.patchConfig(patch);
+  const commitRadioUrl = () => {
+    const value = radioUrl.trim();
+    if (value !== radioUrl) setRadioUrl(value);
+    if (value !== cfg.radioUrl) set({ radioUrl: value });
+  };
   const setField = (k: keyof ShowFields, v: boolean) =>
     conn.patchConfig({ showFields: { ...cfg.showFields, [k]: v } });
+  const statusMessage = state.status?.message ? ` · ${state.status.message}` : "";
 
   return (
     <div className="control">
@@ -69,11 +79,45 @@ export function Control() {
           Ceiling Tracker
         </div>
         <div className="stat">
-          {state.status?.source ?? "—"} · {state.aircraft.length} overhead
+          {state.status?.source ?? "—"} · {state.aircraft.length} overhead{statusMessage}
         </div>
       </header>
 
       <main>
+        <Section title="Source">
+          <Row label="Radio URL" hint="dump1090 aircraft.json">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                commitRadioUrl();
+                (e.currentTarget.elements.namedItem("radioUrl") as HTMLInputElement | null)?.blur();
+              }}
+            >
+              <input
+                name="radioUrl"
+                type="text"
+                inputMode="url"
+                value={radioUrl}
+                onChange={(e) => setRadioUrl(e.target.value)}
+                onBlur={commitRadioUrl}
+                aria-label="Radio aircraft JSON URL"
+                spellCheck={false}
+                style={{
+                  width: "clamp(180px, 48vw, 360px)",
+                  border: "1px solid var(--line)",
+                  borderRadius: 8,
+                  background: "var(--panel-2)",
+                  color: "var(--text)",
+                  fontFamily: "var(--mono)",
+                  fontSize: 12,
+                  padding: "8px 10px",
+                  outline: "none",
+                }}
+              />
+            </form>
+          </Row>
+        </Section>
+
         <Section title="Calibration">
           <Row label="Rotation" hint="align field to ceiling">
             <Slider value={cfg.rotationDeg} min={0} max={355} step={5} unit="°"


### PR DESCRIPTION
## Summary

The dump1090 feed URL is now configurable at runtime. A "Radio URL" field in the control panel's Source section persists to config and the server re-points its polling loop when it changes, so Skylight can consume an existing PiAware / Pi24 / readsb `aircraft.json` feed instead of the bundled receiver setup. An environment-provided `AIRCRAFT_JSON_URL` still seeds the initial value and survives "Reset all to defaults".

## Why this matters

Asked in #3: people already running a dump1090 instance for PiAware or Pi24 want to point Skylight at that feed rather than wiring up a second receiver. Before this change the URL was fixed at startup from the environment, with no way to change it from the UI.

## Changes

- The server builds its defaults from `AIRCRAFT_JSON_URL` (`SERVER_DEFAULT_CONFIG`), so both first-run seeding and "Reset all to defaults" land on the env-derived feed instead of the hard-coded constant. The documented systemd setup serves `/aircraft.json`, not the built-in `/data/aircraft.json`, so persisting the constant on reset would strand that deployment on the wrong feed.
- `radioUrl` writes are validated at the config-store boundary: a `ConfigValidationError` rejects any URL whose scheme is not `http`/`https`, surfaced through both the REST `/api/config` handler and the WebSocket `patchConfig` path. The poller's default target is `localhost` (dump1090 runs on the same host), so the validation is a scheme allowlist rather than a private-address block, which would break the intended local-feed setup. The control panel resets its input to the server's current value when an edit is rejected, so the UI never shows a value the server is not using.

## Testing

- `pnpm typecheck` passes across shared, server, and web packages
- Verified the reset flow re-seeds from the environment URL instead of persisting the built-in default

Closes #3

AI was used for assistance.
