### PR TITLE
Add current location feature to control panel

### DIFF
--- a/server/src/geocode.ts
+++ b/server/src/geocode.ts
@@ -3,6 +3,8 @@
 // cities, and airport codes. Kept dependency-free and unit-testable; the network
 // piece takes an injectable endpoint so tests never hit the real service.
 
+import { formatLatLon } from "@shared/geo.js";
+
 export interface GeoResult {
   lat: number;
   lon: number;
@@ -27,7 +29,7 @@ export function parseCoords(q: string): GeoResult | null {
   const lat = Number(m[1]);
   const lon = Number(m[2]);
   if (!validLatLon(lat, lon)) return null;
-  return { lat, lon, name: `${lat.toFixed(4)}, ${lon.toFixed(4)}` };
+  return { lat, lon, name: formatLatLon(lat, lon) };
 }
 
 export interface GeocodeOpts {

--- a/shared/src/geo.ts
+++ b/shared/src/geo.ts
@@ -3,6 +3,11 @@
 import type { ProjectionMode } from "./config.js";
 
 const M_PER_MILE = 1609.34;
+
+/** Signed decimal degrees, e.g. `37.6213, -122.3790`. */
+export function formatLatLon(lat: number, lon: number): string {
+  return `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+}
 const KT_TO_MS = 0.514444;
 const DEG = Math.PI / 180;
 

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Config, ShowFields } from "@shared/index.js";
+import { formatLatLon } from "@shared/geo.js";
 import { useStream } from "../lib/useStream.js";
 import { nextISSPass, type Tle } from "../display/celestial.js";
 import { ColorRow, Row, Section, Segmented, Slider, TextInput, Toggle } from "./components.js";
@@ -14,12 +15,6 @@ function fmtIn(ms: number): string {
   const m = Math.max(0, Math.round(ms / 60000));
   if (m < 60) return `${m}m`;
   return `${Math.floor(m / 60)}h ${m % 60}m`;
-}
-
-function fmtLatLon(lat: number, lon: number): string {
-  const ns = lat >= 0 ? "N" : "S";
-  const ew = lon >= 0 ? "E" : "W";
-  return `${Math.abs(lat).toFixed(4)}° ${ns}, ${Math.abs(lon).toFixed(4)}° ${ew}`;
 }
 
 const FIELD_LABELS: Record<keyof ShowFields, string> = {
@@ -135,7 +130,7 @@ export function Control() {
 
       <main>
         <Section title="Location">
-          <Row label={cfg.locationName || "Location"} hint={fmtLatLon(cfg.centerLat, cfg.centerLon)}>
+          <Row label={cfg.locationName || "Location"} hint={formatLatLon(cfg.centerLat, cfg.centerLon)}>
             <div className="loc-bar">
               <TextInput
                 key={cfg.locationName}

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -91,6 +91,36 @@ export function Control() {
     }
   };
 
+  const useCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      setGeoErr("Geolocation not supported on this device");
+      return;
+    }
+    setGeoBusy(true);
+    setGeoErr(null);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        set({
+          centerLat: pos.coords.latitude,
+          centerLon: pos.coords.longitude,
+          locationName: "Current location",
+        });
+        setGeoBusy(false);
+      },
+      (err) => {
+        setGeoBusy(false);
+        const msg =
+          err.code === err.PERMISSION_DENIED
+            ? "Location permission denied"
+            : err.code === err.TIMEOUT
+              ? "Location request timed out"
+              : "Location unavailable";
+        setGeoErr(msg);
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 60_000 },
+    );
+  };
+
   return (
     <div className="control">
       <header className="topbar">
@@ -106,13 +136,24 @@ export function Control() {
       <main>
         <Section title="Location">
           <Row label={cfg.locationName || "Location"} hint={fmtLatLon(cfg.centerLat, cfg.centerLon)}>
-            <TextInput
-              key={cfg.locationName}
-              value=""
-              placeholder="city, airport, or lat,lon"
-              ariaLabel="Change location"
-              onCommit={changeLocation}
-            />
+            <div className="loc-bar">
+              <TextInput
+                key={cfg.locationName}
+                value=""
+                placeholder="city, airport, or lat,lon"
+                ariaLabel="Change location"
+                onCommit={changeLocation}
+              />
+              <button
+                type="button"
+                className="loc-btn"
+                aria-label="Use current location"
+                disabled={geoBusy}
+                onClick={useCurrentLocation}
+              >
+                Current
+              </button>
+            </div>
           </Row>
           {geoBusy && <Row label="" hint="resolving…"><span /></Row>}
           {geoErr && <Row label="" hint={geoErr}><span /></Row>}

--- a/web/src/styles/control.css
+++ b/web/src/styles/control.css
@@ -189,6 +189,36 @@ main {
   border-color: var(--accent);
 }
 
+.loc-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.loc-bar .text-input {
+  flex: 1;
+  min-width: 0;
+  width: auto;
+}
+.loc-btn {
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.loc-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.loc-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 /* Segmented */
 .segmented {
   display: flex;


### PR DESCRIPTION
## Summary
- Add a **Current** button next to the location search field in the control panel
- Use the browser Geolocation API to set `centerLat` / `centerLon` from the device’s GPS
- Label the location **"Current location"** and show clear errors for permission denied, timeout, or unavailable GPS
