### PR TITLE
Add airport importer and automatic display refresh

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -133,6 +133,48 @@ async function main(): Promise<void> {
   app.post("/api/config/reset", (_req, res) => res.json(store.reset()));
   app.get("/api/aircraft", (_req, res) => res.json(poller.getSnapshot()));
   app.get("/api/status", (_req, res) => res.json(poller.getStatus()));
+app.post("/api/import-airport", async (req, res) => {
+  const code = String(req.body?.code ?? "").trim().toUpperCase();
+
+  if (!/^[A-Z0-9]{3,5}$/.test(code)) {
+    return res.status(400).json({ error: "Airport code must look like KSNA, KCNO, KFUL, etc." });
+  }
+
+  try {
+    const { execFileSync } = await import("node:child_process");
+
+    execFileSync("node", ["tools/import-airport.cjs", code], {
+      cwd: resolve(__dirname, "../.."),
+      stdio: "inherit",
+    });
+
+    execFileSync("pnpm", ["build"], {
+      cwd: resolve(__dirname, "../.."),
+      stdio: "inherit",
+    });
+
+    res.json({
+      ok: true,
+      code,
+      message: `Imported ${code}. Restarting Skylight server now. Refresh the display after a few seconds.`,
+    });
+
+    setTimeout(() => {
+      try {
+        execFileSync("sudo", ["-n", "systemctl", "restart", "skylight-server"], {
+          stdio: "ignore",
+        });
+      } catch {
+        // server may die during restart; ignore here
+      }
+    }, 1000);
+  } catch (err) {
+    res.status(500).json({
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
   app.get("/api/tle", async (_req, res) => res.json(await tleStore.get()));
   app.post("/api/source", (req, res) => {
     const s = req.body?.source;
@@ -169,6 +211,37 @@ async function main(): Promise<void> {
         .send("Web build not found. Run `npm run build`, or use the Vite dev server."),
     );
   }
+
+app.get("/api/reload-version", async (_req, res) => {
+  try {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+
+    const reloadPath = path.resolve(
+      process.cwd(),
+      "data/reload.json"
+    );
+
+    console.log("Reload endpoint reading:", reloadPath);
+
+    if (!fs.existsSync(reloadPath)) {
+      return res.json({
+        error: "file not found",
+        path: reloadPath,
+      });
+    }
+
+    const data = JSON.parse(
+      fs.readFileSync(reloadPath, "utf8")
+    );
+
+    res.json(data);
+  } catch (err) {
+    res.json({
+      error: String(err),
+    });
+  }
+});
 
   poller.start();
 

--- a/tools/airport-block.cjs
+++ b/tools/airport-block.cjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const https = require("https");
+
+const QUERY = (process.argv[2] || "").toUpperCase();
+
+if (!QUERY) {
+  console.error("Usage: node tools/airport-block.cjs KCNO");
+  process.exit(1);
+}
+
+const ROOT = path.resolve(__dirname, "..");
+const DATA_DIR = path.join(ROOT, "tools", "ourairports-cache");
+
+const AIRPORTS_URL = "https://davidmegginson.github.io/ourairports-data/airports.csv";
+const RUNWAYS_URL = "https://davidmegginson.github.io/ourairports-data/runways.csv";
+
+function download(url, file) {
+  return new Promise((resolve, reject) => {
+    if (fs.existsSync(file)) return resolve();
+
+    console.log(`Downloading ${url}`);
+    const out = fs.createWriteStream(file);
+
+    https
+      .get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed: ${res.statusCode}`));
+          return;
+        }
+
+        res.pipe(out);
+        out.on("finish", () => out.close(resolve));
+      })
+      .on("error", reject);
+  });
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let cell = "";
+  let quoted = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    const n = text[i + 1];
+
+    if (quoted) {
+      if (c === '"' && n === '"') {
+        cell += '"';
+        i++;
+      } else if (c === '"') {
+        quoted = false;
+      } else {
+        cell += c;
+      }
+    } else {
+      if (c === '"') quoted = true;
+      else if (c === ",") {
+        row.push(cell);
+        cell = "";
+      } else if (c === "\n") {
+        row.push(cell);
+        rows.push(row);
+        row = [];
+        cell = "";
+      } else if (c !== "\r") {
+        cell += c;
+      }
+    }
+  }
+
+  if (cell.length || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  const headers = rows.shift();
+  return rows.map((r) =>
+    Object.fromEntries(headers.map((h, i) => [h, r[i] || ""]))
+  );
+}
+
+function num(v) {
+  if (v === undefined || v === null || v === "") return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function safeConstName(ident) {
+  return ident.replace(/[^A-Z0-9_]/g, "_");
+}
+
+(async () => {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+
+  const airportsFile = path.join(DATA_DIR, "airports.csv");
+  const runwaysFile = path.join(DATA_DIR, "runways.csv");
+
+  await download(AIRPORTS_URL, airportsFile);
+  await download(RUNWAYS_URL, runwaysFile);
+
+  const airports = parseCsv(fs.readFileSync(airportsFile, "utf8"));
+  const runways = parseCsv(fs.readFileSync(runwaysFile, "utf8"));
+
+  const airport =
+    airports.find((a) => a.ident.toUpperCase() === QUERY) ||
+    airports.find((a) => a.gps_code.toUpperCase() === QUERY) ||
+    airports.find((a) => a.local_code.toUpperCase() === QUERY) ||
+    airports.find((a) => a.iata_code.toUpperCase() === QUERY) ||
+    airports.find((a) => a.name.toUpperCase().includes(QUERY));
+
+  if (!airport) {
+    console.error(`Airport not found: ${QUERY}`);
+    process.exit(1);
+  }
+
+  const airportRunways = runways
+    .filter((r) => r.airport_ident === airport.ident && r.closed !== "1")
+    .map((r) => ({
+      leIdent: r.le_ident,
+      heIdent: r.he_ident,
+      leLat: num(r.le_latitude_deg),
+      leLon: num(r.le_longitude_deg),
+      heLat: num(r.he_latitude_deg),
+      heLon: num(r.he_longitude_deg),
+      widthFt: num(r.width_ft) || 150,
+    }))
+    .filter((r) =>
+      r.leIdent &&
+      r.heIdent &&
+      r.leLat !== null &&
+      r.leLon !== null &&
+      r.heLat !== null &&
+      r.heLon !== null
+    );
+
+  if (!airportRunways.length) {
+    console.error(`No usable runway data found for ${airport.ident}`);
+    process.exit(1);
+  }
+
+  const ident = airport.ident;
+  const constName = safeConstName(ident);
+  const airportName = airport.name || ident;
+  const centerLat = num(airport.latitude_deg);
+  const centerLon = num(airport.longitude_deg);
+
+  console.log("");
+  console.log("/* ---------- COPY BELOW INTO airports.ts ---------- */");
+  console.log("");
+  console.log(`export const ${constName}: Airport = {`);
+  console.log(`  icao: "${ident}",`);
+  console.log(`  name: "${airportName}",`);
+  console.log(`  runways: [`);
+
+  for (const r of airportRunways) {
+    console.log(
+      `    { leIdent: "${r.leIdent}", heIdent: "${r.heIdent}", le: [${r.leLat}, ${r.leLon}], he: [${r.heLat}, ${r.heLon}], widthFt: ${r.widthFt} },`
+    );
+  }
+
+  console.log(`  ],`);
+  console.log(`};`);
+  console.log("");
+  console.log(`export const AIRPORTS: Airport[] = [${constName}];`);
+  console.log("");
+  console.log("/* ---------- CONFIG.JSON CENTER ---------- */");
+  console.log(`"centerLat": ${centerLat},`);
+  console.log(`"centerLon": ${centerLon},`);
+  console.log("");
+})();

--- a/tools/import-airport.cjs
+++ b/tools/import-airport.cjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const airportCode = process.argv[2]?.toUpperCase();
+
+if (!airportCode) {
+  console.error("Usage: node tools/import-airport.cjs KCNO");
+  process.exit(1);
+}
+
+const root = path.resolve(__dirname, "..");
+const airportsPath = path.join(root, "web/src/display/airports.ts");
+const configPath = path.join(root, "server/data/config.json");
+const reloadPath = path.join(root, "server/data/reload.json");
+const blockScript = path.join(root, "tools/airport-block.cjs");
+
+const output = execSync(`node "${blockScript}" ${airportCode}`, {
+  encoding: "utf8",
+});
+
+const fullMatch = output.match(
+  /export const\s+([A-Z0-9_]+):\s*Airport\s*=\s*{[\s\S]*?};\s*\n\s*export const AIRPORTS:\s*Airport\[\]\s*=\s*\[[A-Z0-9_,\s]+\];/
+);
+
+if (!fullMatch) {
+  console.error("Could not find generated airport block in script output.");
+  console.error(output);
+  process.exit(1);
+}
+
+const newConstName = fullMatch[1];
+
+const airportOnlyMatch = fullMatch[0].match(
+  /export const\s+[A-Z0-9_]+:\s*Airport\s*=\s*{[\s\S]*?};/
+);
+
+if (!airportOnlyMatch) {
+  console.error("Could not isolate generated airport block.");
+  process.exit(1);
+}
+
+const newAirportBlock = airportOnlyMatch[0];
+
+const oldFile = fs.readFileSync(airportsPath, "utf8");
+//const backupPath = `${airportsPath}.backup-${Date.now()}`;
+//fs.writeFileSync(backupPath, oldFile);
+
+const airportBlockRegex = new RegExp(
+  `export const\\s+${newConstName}:\\s*Airport\\s*=\\s*{[\\s\\S]*?};`,
+  "m"
+);
+
+let updatedFile = oldFile;
+
+if (airportBlockRegex.test(updatedFile)) {
+  updatedFile = updatedFile.replace(airportBlockRegex, newAirportBlock);
+  console.log(`Updated existing airport block: ${newConstName}`);
+} else {
+  const airportsListRegex = /export const AIRPORTS:\s*Airport\[\]\s*=\s*\[[\s\S]*?\];/m;
+
+  if (!airportsListRegex.test(updatedFile)) {
+    console.error("Could not find AIRPORTS list.");
+   // console.error(`Backup saved at: ${backupPath}`);
+    process.exit(1);
+  }
+
+  updatedFile = updatedFile.replace(airportsListRegex, `${newAirportBlock}\n\n$&`);
+  console.log(`Added new airport block: ${newConstName}`);
+}
+
+const airportsListRegex = /export const AIRPORTS:\s*Airport\[\]\s*=\s*\[([\s\S]*?)\];/m;
+const listMatch = updatedFile.match(airportsListRegex);
+
+if (!listMatch) {
+  console.error("Could not find AIRPORTS list after update.");
+ // console.error(`Backup saved at: ${backupPath}`);
+  process.exit(1);
+}
+
+const existingNames = listMatch[1]
+  .split(",")
+  .map((x) => x.trim())
+  .filter(Boolean);
+
+if (!existingNames.includes(newConstName)) {
+  existingNames.push(newConstName);
+}
+
+const newList = `export const AIRPORTS: Airport[] = [${existingNames.join(", ")}];`;
+updatedFile = updatedFile.replace(airportsListRegex, newList);
+
+fs.writeFileSync(airportsPath, updatedFile);
+
+const centerMatch = output.match(/"centerLat":\s*([-0-9.]+),\s*\n"centerLon":\s*([-0-9.]+),/);
+
+if (centerMatch && fs.existsSync(configPath)) {
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  config.centerLat = Number(centerMatch[1]);
+  config.centerLon = Number(centerMatch[2]);
+  config.locationName = airportCode;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  console.log(`Updated config center to ${config.centerLat}, ${config.centerLon}`);
+}
+
+if (fs.existsSync(reloadPath)) {
+  const reloadData = {
+    reloadVersion: Date.now(),
+  };
+
+  fs.writeFileSync(
+    reloadPath,
+    JSON.stringify(reloadData, null, 2) + "\n"
+  );
+
+  console.log("Display reload requested.");
+}
+
+console.log(`Imported airport ${airportCode} as ${newConstName}`);
+console.log(`Updated: ${airportsPath}`);
+//console.log(`Backup: ${backupPath}`);

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -35,6 +35,9 @@ export function Control() {
   // Location editor (Nominatim via the server's /api/geocode).
   const [geoBusy, setGeoBusy] = useState(false);
   const [geoErr, setGeoErr] = useState<string | null>(null);
+  const [airportImportCode, setAirportImportCode] = useState("");
+  const [airportImportBusy, setAirportImportBusy] = useState(false);
+  const [airportImportMsg, setAirportImportMsg] = useState<string | null>(null);
 
   // ISS pass finder (for the Sky section).
   const [tles, setTles] = useState<Tle[]>([]);
@@ -83,6 +86,39 @@ export function Control() {
       setGeoErr("Lookup failed");
     } finally {
       setGeoBusy(false);
+    }
+  };
+
+  const importAirportRunways = async () => {
+    const code = airportImportCode.trim().toUpperCase();
+    if (!code) {
+      setAirportImportMsg("Enter an airport code first, like KSNA or KCNO.");
+      return;
+    }
+
+    setAirportImportBusy(true);
+    setAirportImportMsg(`Importing ${code} runways…`);
+
+    try {
+      const r = await fetch("/api/import-airport", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+
+      const data = await r.json().catch(() => ({}));
+
+      if (!r.ok) {
+        setAirportImportMsg(data.error || `Import failed for ${code}`);
+        return;
+      }
+
+      setAirportImportMsg(`Imported ${code}. Refreshing display shortly…`);
+      setTimeout(() => window.location.reload(), 5000);
+    } catch {
+      setAirportImportMsg("Import failed. Check Skylight server logs.");
+    } finally {
+      setAirportImportBusy(false);
     }
   };
 
@@ -179,6 +215,26 @@ export function Control() {
               </button>
             </div>
           </Row>
+          <Row label="Runway overlay" hint="imports runway geometry from OurAirports">
+            <div className="loc-bar">
+              <input
+                className="text-input"
+                value={airportImportCode}
+                placeholder="KSNA, KCNO, KFUL..."
+                aria-label="Airport runway import code"
+                onChange={(e) => setAirportImportCode(e.target.value.toUpperCase())}
+              />
+              <button
+                type="button"
+                className="loc-btn"
+                disabled={airportImportBusy}
+                onClick={importAirportRunways}
+              >
+                {airportImportBusy ? "Importing…" : "Import"}
+              </button>
+            </div>
+          </Row>
+          {airportImportMsg && <Row label="" hint={airportImportMsg}><span /></Row>}
           {geoBusy && <Row label="" hint="resolving…"><span /></Row>}
           {geoErr && <Row label="" hint={geoErr}><span /></Row>}
           <div className="chips">

--- a/web/src/display/main.tsx
+++ b/web/src/display/main.tsx
@@ -3,6 +3,36 @@ import { createRoot } from "react-dom/client";
 import { Display } from "./Display.js";
 import "../styles/display.css";
 
+let lastReloadVersion: number | null = null;
+let sawReloadEndpoint = false;
+
+setInterval(async () => {
+  try {
+    const r = await fetch("/api/reload-version", { cache: "no-store" });
+    if (!r.ok) return;
+
+    const data = await r.json();
+    const version = Number(data.reloadVersion);
+
+    if (!Number.isFinite(version)) return;
+
+    if (lastReloadVersion === null) {
+      lastReloadVersion = version;
+      sawReloadEndpoint = true;
+      return;
+    }
+
+    if (sawReloadEndpoint && version !== lastReloadVersion) {
+      setTimeout(() => window.location.reload(), 10000);
+    }
+
+    lastReloadVersion = version;
+    sawReloadEndpoint = true;
+  } catch {
+    // Server may be restarting; try again on next interval.
+  }
+}, 10000);
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Display />


### PR DESCRIPTION
Adds an airport importer function and button to the Control page in order to simplify adding additional airports with runways and switching between them.

Features:
- Import airports by ICAO, FAA, GPS, or airport name
- Downloads runway data from OurAirports
- Automatically adds runway overlays to the display
- Automatic display refresh after import & server reboots (not Pi)
- No manual editing of airports.ts required

Tested on Raspberry Pi 4 deployment.

Example:
- KSNA
- KFUL
- KLAX
- Airport name searches

import-airport.cjs now updates server/data/config.json center coordinates automatically.

Added reusable airport generation/import tooling (airport-block.cjs).

This PR intentionally excludes user-specific airport library data.