### PR TITLE
fix: actionable geolocation guidance when the control panel runs over insecure HTTP

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
-export default defineConfig({
+export default {
   resolve: {
     alias: { "@shared": resolve(__dirname, "shared/src") },
   },
@@ -13,4 +12,4 @@ export default defineConfig({
       "web/test/**/*.test.ts",
     ],
   },
-});
+};

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Airport, Config, ShowFields, LocationProfile } from "@shared/index.js";
 import { formatLatLon } from "@shared/geo.js";
+import { geoAvailability, geoErrorMessage } from "../lib/geolocation.js";
 import { useStream } from "../lib/useStream.js";
 import { nextISSPass, type Tle } from "../display/celestial.js";
 import { ColorRow, Row, Section, Segmented, Slider, TextInput, Toggle } from "./components.js";
@@ -146,8 +147,13 @@ export function Control() {
     });
 
   const useCurrentLocation = () => {
-    if (!navigator.geolocation) {
-      setGeoErr("Geolocation not supported on this device");
+    const availability = geoAvailability({
+      hasGeolocation: Boolean(navigator.geolocation),
+      isSecureContext: window.isSecureContext,
+      hostname: window.location.hostname,
+    });
+    if (!availability.ok) {
+      setGeoErr(availability.message);
       return;
     }
     setGeoBusy(true);
@@ -163,13 +169,13 @@ export function Control() {
       },
       (err) => {
         setGeoBusy(false);
-        const msg =
-          err.code === err.PERMISSION_DENIED
-            ? "Location permission denied"
-            : err.code === err.TIMEOUT
-              ? "Location request timed out"
-              : "Location unavailable";
-        setGeoErr(msg);
+        const insecureContext =
+          !geoAvailability({
+            hasGeolocation: true,
+            isSecureContext: window.isSecureContext,
+            hostname: window.location.hostname,
+          }).ok;
+        setGeoErr(geoErrorMessage(err.code, insecureContext));
       },
       { enableHighAccuracy: true, timeout: 15000, maximumAge: 60_000 },
     );

--- a/web/src/lib/geolocation.ts
+++ b/web/src/lib/geolocation.ts
@@ -1,0 +1,56 @@
+export const GEO_UNSUPPORTED_MESSAGE = "Geolocation not supported on this device";
+export const GEO_INSECURE_CONTEXT_MESSAGE =
+  "Browsers block geolocation on plain HTTP - type a city, airport code, or lat,lon instead";
+
+export type GeoAvailabilityReason = "unsupported" | "insecure-context";
+
+export type GeoAvailability =
+  | { ok: true }
+  | { ok: false; reason: GeoAvailabilityReason; message: string };
+
+export interface GeoAvailabilityInput {
+  hasGeolocation: boolean;
+  isSecureContext: boolean;
+  hostname: string;
+}
+
+const PERMISSION_DENIED = 1;
+const TIMEOUT = 3;
+
+function isLocalHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+export function geoAvailability({
+  hasGeolocation,
+  isSecureContext,
+  hostname,
+}: GeoAvailabilityInput): GeoAvailability {
+  if (!hasGeolocation) {
+    return { ok: false, reason: "unsupported", message: GEO_UNSUPPORTED_MESSAGE };
+  }
+  if (!isSecureContext && !isLocalHostname(hostname)) {
+    return { ok: false, reason: "insecure-context", message: GEO_INSECURE_CONTEXT_MESSAGE };
+  }
+  return { ok: true };
+}
+
+export function geoErrorMessage(code: number, insecure: boolean): string {
+  if (code === PERMISSION_DENIED && insecure) {
+    return GEO_INSECURE_CONTEXT_MESSAGE;
+  }
+  if (code === PERMISSION_DENIED) {
+    return "Location permission denied";
+  }
+  if (code === TIMEOUT) {
+    return "Location request timed out";
+  }
+  return "Location unavailable";
+}

--- a/web/src/lib/geolocation.ts
+++ b/web/src/lib/geolocation.ts
@@ -33,11 +33,11 @@ export function geoAvailability({
   isSecureContext,
   hostname,
 }: GeoAvailabilityInput): GeoAvailability {
-  if (!hasGeolocation) {
-    return { ok: false, reason: "unsupported", message: GEO_UNSUPPORTED_MESSAGE };
-  }
   if (!isSecureContext && !isLocalHostname(hostname)) {
     return { ok: false, reason: "insecure-context", message: GEO_INSECURE_CONTEXT_MESSAGE };
+  }
+  if (!hasGeolocation) {
+    return { ok: false, reason: "unsupported", message: GEO_UNSUPPORTED_MESSAGE };
   }
   return { ok: true };
 }

--- a/web/test/geolocation.test.ts
+++ b/web/test/geolocation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  GEO_INSECURE_CONTEXT_MESSAGE,
+  GEO_UNSUPPORTED_MESSAGE,
+  geoAvailability,
+  geoErrorMessage,
+} from "../src/lib/geolocation.js";
+
+describe("geoAvailability", () => {
+  it("allows geolocation in secure contexts when the API is present", () => {
+    expect(
+      geoAvailability({ hasGeolocation: true, isSecureContext: true, hostname: "skylight.local" }),
+    ).toEqual({ ok: true });
+  });
+
+  it("blocks insecure LAN hosts with actionable fallback guidance", () => {
+    expect(
+      geoAvailability({ hasGeolocation: true, isSecureContext: false, hostname: "192.168.1.25" }),
+    ).toEqual({
+      ok: false,
+      reason: "insecure-context",
+      message: GEO_INSECURE_CONTEXT_MESSAGE,
+    });
+  });
+
+  it("allows localhost over HTTP as a secure browser context", () => {
+    expect(
+      geoAvailability({ hasGeolocation: true, isSecureContext: true, hostname: "localhost" }),
+    ).toEqual({ ok: true });
+  });
+
+  it("also treats loopback hostnames as local when context flags are unavailable", () => {
+    expect(
+      geoAvailability({ hasGeolocation: true, isSecureContext: false, hostname: "localhost" }),
+    ).toEqual({ ok: true });
+    expect(
+      geoAvailability({ hasGeolocation: true, isSecureContext: false, hostname: "127.0.0.1" }),
+    ).toEqual({ ok: true });
+  });
+
+  it("reports unsupported devices before checking context security", () => {
+    expect(
+      geoAvailability({ hasGeolocation: false, isSecureContext: false, hostname: "192.168.1.25" }),
+    ).toEqual({
+      ok: false,
+      reason: "unsupported",
+      message: GEO_UNSUPPORTED_MESSAGE,
+    });
+  });
+});
+
+describe("geoErrorMessage", () => {
+  it("turns insecure permission denial into HTTP guidance", () => {
+    expect(geoErrorMessage(1, true)).toBe(GEO_INSECURE_CONTEXT_MESSAGE);
+  });
+
+  it("keeps the existing secure-context permission denial message", () => {
+    expect(geoErrorMessage(1, false)).toBe("Location permission denied");
+  });
+
+  it("keeps timeout and generic unavailable messages", () => {
+    expect(geoErrorMessage(3, false)).toBe("Location request timed out");
+    expect(geoErrorMessage(2, false)).toBe("Location unavailable");
+  });
+});

--- a/web/test/geolocation.test.ts
+++ b/web/test/geolocation.test.ts
@@ -38,9 +38,19 @@ describe("geoAvailability", () => {
     ).toEqual({ ok: true });
   });
 
-  it("reports unsupported devices before checking context security", () => {
+  it("blocks insecure LAN hosts even when browsers hide the API", () => {
     expect(
       geoAvailability({ hasGeolocation: false, isSecureContext: false, hostname: "192.168.1.25" }),
+    ).toEqual({
+      ok: false,
+      reason: "insecure-context",
+      message: GEO_INSECURE_CONTEXT_MESSAGE,
+    });
+  });
+
+  it("reports unsupported devices in secure contexts", () => {
+    expect(
+      geoAvailability({ hasGeolocation: false, isSecureContext: true, hostname: "skylight.local" }),
     ).toEqual({
       ok: false,
       reason: "unsupported",


### PR DESCRIPTION
## Summary

The control panel's "use current location" button no longer dead-ends with "Location permission denied" on plain-HTTP LAN deployments. Browsers hard-block `navigator.geolocation` in insecure contexts (immediate PERMISSION_DENIED regardless of site settings), which is exactly how Skylight is canonically served from a Pi or Jetson. The control panel now detects this case and shows actionable guidance ("Browsers block geolocation on plain HTTP - type a city, airport code, or lat,lon instead") while genuine user denials keep the existing message.

## Why this matters

#23: the Jetson Nano reporter could never fix this by toggling site permissions, since the block is enforced by the insecure context, not by a setting. The insecure-context classification runs before the API-support check, because browsers can hide secure-context-only APIs entirely on HTTP LAN URLs (`navigator.geolocation` undefined), and that scenario must read as "insecure context" rather than "unsupported browser". The issue's other complaint (USA-only airports, ignored lat/lon) was already fixed on main by the worldwide runway importer and `/api/geocode` parsing in a641e86.

## Changes

- New pure helpers in `web/src/lib/geolocation.ts`: `geoAvailability` (no-API vs insecure-context vs available, with insecure checked first) and `geoErrorMessage` (PERMISSION_DENIED in an insecure context maps to the HTTP guidance). Both are DOM-global-free so they test under the plain-node vitest setup.
- `Control.tsx` consults the helper before calling `getCurrentPosition` and routes the error callback through the mapper, surfacing messages via the existing `geoErr` row.

## Testing

New `web/test/geolocation.test.ts` covers the classification order (insecure-before-unsupported), localhost and HTTPS allowed paths, and the error-message mapping; suite, typecheck, and build pass locally.

Fixes #23
