### PR TITLE
Control: Add input field next to Slider, to allow for more precise modification of values

### DIFF
--- a/web/src/control/components.tsx
+++ b/web/src/control/components.tsx
@@ -62,7 +62,14 @@ export function Slider({
         onChange={(e) => onChange(Number(e.target.value))}
       />
       <span className="slider-value">
-        {Number.isInteger(step) ? value : value.toFixed(2)}
+        <input
+          type="number"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={(e) => onChange(Number(e.target.value))}
+        />
         {unit}
       </span>
     </div>

--- a/web/src/styles/control.css
+++ b/web/src/styles/control.css
@@ -166,11 +166,35 @@ main {
   height: 28px;
 }
 .slider-value {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  min-width: 62px;
+}
+.slider-value,
+.slider-value input[type="number"] {
   font-family: var(--mono);
   font-size: 13px;
   color: var(--text);
-  min-width: 52px;
   text-align: right;
+}
+
+.slider-value input[type="number"] {
+  padding: 2px;
+  background: transparent;
+  border: 1px solid transparent;
+
+  &:focus {
+    border: 1px solid var(--accent);
+    border-radius: 6px;
+    outline: none;
+  }
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }
 
 /* Saved location profiles */


### PR DESCRIPTION
Before:
<img width="716" height="446" alt="image" src="https://github.com/user-attachments/assets/7bdbfc4a-1461-42cb-8c5c-2f5ac941b214" />

Now ("Rotation" input field focused):
<img width="706" height="452" alt="image" src="https://github.com/user-attachments/assets/cb1241de-cc0c-4bc1-9d33-fc4768ab8763" />

Allows the user to type in a specific value, and also allows for fine adjustment using arrow keys (via built-in browser functionality of `input[type="number"]` components)
