### PR TITLE
Control: only show settings related to Stars when Stars is enabled, group Stars-related controls with the Stars toggle

### DIFF
--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -426,6 +426,18 @@ export function Control() {
           <Row label="Stars">
             <Toggle value={cfg.showStars} onChange={(v) => set({ showStars: v })} />
           </Row>
+          {cfg.showStars && (
+            <>
+              <Row label="Star density" indent={true}>
+                <Slider value={cfg.starMagLimit} min={1} max={4} step={0.1}
+                  onChange={(v) => set({ starMagLimit: v })} />
+              </Row>
+              <Row label="Star labels" hint="higher = more names" indent={true}>
+                <Slider value={cfg.starLabelMagLimit} min={0} max={3} step={0.1}
+                  onChange={(v) => set({ starLabelMagLimit: v })} />
+              </Row>
+            </>
+          )}
           <Row label="Sun">
             <Toggle value={cfg.showSun} onChange={(v) => set({ showSun: v })} />
           </Row>
@@ -442,14 +454,6 @@ export function Control() {
           )}
           <Row label="Planets" hint="Venus, Jupiter, Mars…">
             <Toggle value={cfg.showPlanets} onChange={(v) => set({ showPlanets: v })} />
-          </Row>
-          <Row label="Star density">
-            <Slider value={cfg.starMagLimit} min={1} max={4} step={0.1}
-              onChange={(v) => set({ starMagLimit: v })} />
-          </Row>
-          <Row label="Star labels" hint="higher = more names">
-            <Slider value={cfg.starLabelMagLimit} min={0} max={3} step={0.1}
-              onChange={(v) => set({ starLabelMagLimit: v })} />
           </Row>
           <Row label="Sky time" hint={skyTimeLabel(cfg.skyTimeOffsetMin)}>
             <Slider value={cfg.skyTimeOffsetMin} min={-720} max={720} step={5} unit="m"

--- a/web/src/control/components.tsx
+++ b/web/src/control/components.tsx
@@ -11,9 +11,9 @@ export function Section({ title, children }: { title: string; children: ReactNod
   );
 }
 
-export function Row({ label, children, hint }: { label: string; children: ReactNode; hint?: string }) {
+export function Row({ label, children, hint, indent = false }: { label: string; children: ReactNode; hint?: string; indent?: boolean }) {
   return (
-    <div className="row">
+    <div className={`row ${indent ? "row-indent" : ""}`}>
       <div className="row-label">
         {label}
         {hint && <span className="row-hint">{hint}</span>}

--- a/web/src/styles/control.css
+++ b/web/src/styles/control.css
@@ -106,6 +106,9 @@ main {
   padding: 13px 14px;
   border-top: 1px solid var(--line);
 }
+.row-indent {
+  padding-left: 28px;
+}
 .row:first-child {
   border-top: none;
 }


### PR DESCRIPTION
Before:

<img width="728" height="696" alt="image" src="https://github.com/user-attachments/assets/199e5066-1756-416f-bf5e-3e6bbc416e7e" />


Now:

<img width="726" height="698" alt="image" src="https://github.com/user-attachments/assets/82518e88-2c65-4d19-adc4-9cd62463ad24" />

