### PR TITLE
Control: add Plane Preview Card

### DIFF
--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -403,7 +403,7 @@ export function Control() {
             <div className="plane-preview-card">
               {
                 planePreview.map(
-                  (row) => {
+                  (row, index) => {
                     const text = row?.text?.split(/\s{2,}/);
 
                     if (!text) {
@@ -411,7 +411,7 @@ export function Control() {
                     }
 
                     return (
-                      <div className={`plane-preview-card-row plane-preview-card-row-${row?.kind}`}>
+                      <div key={`plane-preview-row-${index}`} className={`plane-preview-card-row plane-preview-card-row-${row?.kind}`}>
                         {text.map((t) => (<span key={t}>{t}</span>))}
                       </div>
                     );

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -3,6 +3,7 @@ import type { Airport, Config, ShowFields, LocationProfile } from "@shared/index
 import { formatLatLon } from "@shared/geo.js";
 import { useStream } from "../lib/useStream.js";
 import { nextISSPass, type Tle } from "../display/celestial.js";
+import { labelLines } from "../display/renderer.js";
 import { ColorRow, Row, Section, Segmented, Slider, TextInput, Toggle } from "./components.js";
 
 function skyTimeLabel(offsetMin: number): string {
@@ -174,6 +175,34 @@ export function Control() {
       { enableHighAccuracy: true, timeout: 15000, maximumAge: 60_000 },
     );
   };
+
+  // plane preview card
+  const planePreview = labelLines(
+    cfg,
+    {
+      "hex": "4cad7b",
+      "flight": "BA001",
+      "lat": 52.4841701,
+      "lon": -1.9037858,
+      "altBaro": 60000,
+      "altGeom": 24325,
+      "gs": 1173.118,
+      "track": 155.18,
+      "baroRate": -1536,
+      "registration": "G-BOAA",
+      "typeCode": "CONC",
+      "typeName": "Concorde",
+      "airline": "British Airways",
+      "origin": "JFK",
+      "destination": "LHR",
+      "originName": "New York",
+      "destName": "London",
+      "originLat": 40.641766,
+      "originLon": -73.780968,
+      "destLat": 51.4706,
+      "destLon": -0.461941
+    },
+  );
 
   return (
     <div className="control">
@@ -357,14 +386,39 @@ export function Control() {
               ]}
               onChange={(v) => set({ speedUnit: v })} />
           </Row>
-          <div className="chips">
-            {(Object.keys(FIELD_LABELS) as (keyof ShowFields)[]).map((k) => (
-              <button key={k}
-                className={`chip ${cfg.showFields[k] ? "on" : ""}`}
-                onClick={() => setField(k, !cfg.showFields[k])}>
-                {FIELD_LABELS[k]}
-              </button>
-            ))}
+
+          <div className="plane-preview">
+            <h3 className="plane-preview-title">Plane detail</h3>
+            <div className="chips">
+              {(Object.keys(FIELD_LABELS) as (keyof ShowFields)[]).map((k) => (
+                <button key={k}
+                  className={`chip ${cfg.showFields[k] ? "on" : ""}`}
+                  onClick={() => setField(k, !cfg.showFields[k])}>
+                  {FIELD_LABELS[k]}
+                </button>
+              ))}
+            </div>
+
+            <h3 className="plane-preview-title">Preview</h3>
+            <div className="plane-preview-card">
+              {
+                planePreview.map(
+                  (row) => {
+                    const text = row?.text?.split(/\s{2,}/);
+
+                    if (!text) {
+                      return null;
+                    }
+
+                    return (
+                      <div className={`plane-preview-card-row plane-preview-card-row-${row?.kind}`}>
+                        {text.map((t) => (<span key={t}>{t}</span>))}
+                      </div>
+                    );
+                  }
+                )
+              }
+            </div>
           </div>
         </Section>
 

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -102,6 +102,38 @@ function altRamp(alt: number): [number, number, number] {
   return ALT_STOPS[ALT_STOPS.length - 1][1];
 }
 
+export function labelLines(cfg: Config, ac: Aircraft): { text: string; kind: "title" | "sub" }[] {
+  const f = cfg.showFields;
+  const out: { text: string; kind: "title" | "sub" }[] = [];
+  const title = f.flight ? ac.flight ?? ac.hex.toUpperCase() : ac.airline;
+  if (title) out.push({ text: title, kind: "title" });
+
+  const sub: string[] = [];
+  if (f.type && (ac.typeName || ac.typeCode)) sub.push(ac.typeName ?? ac.typeCode!);
+  const alt = ac.altBaro ?? ac.altGeom;
+  if (f.altitude) {
+    if (ac.onGround) sub.push("GND");
+    else if (alt != null) sub.push(`${alt.toLocaleString("en-US")} ft`);
+  }
+  if (f.speed && ac.gs != null) sub.push(formatSpeed(ac.gs, cfg.speedUnit));
+  if (sub.length) out.push({ text: sub.join("   "), kind: "sub" });
+
+  if (f.destination && ac.destination && routePlausible(ac, cfg)) {
+    const head = ac.origin ? `${ac.origin} → ${ac.destination}` : `→ ${ac.destination}`;
+    out.push({ text: ac.destName ? `${head}   ${ac.destName}` : head, kind: "sub" });
+    if (cfg.showRouteDetail && ac.destLat != null && ac.destLon != null) {
+      const bits: string[] = [`${localTimeAt(ac.destLat, ac.destLon)} local`];
+      if (ac.lat != null && ac.lon != null) {
+        const mi = Math.round(greatCircleMiles(ac.lat, ac.lon, ac.destLat, ac.destLon));
+        if (mi > 1) bits.push(`${mi.toLocaleString("en-US")} mi to go`);
+      }
+      out.push({ text: bits.join("   ·   "), kind: "sub" });
+    }
+  }
+  if (f.registration && ac.registration) out.push({ text: ac.registration, kind: "sub" });
+  return out;
+}
+
 const rgba = (c: [number, number, number], a: number) =>
   `rgba(${c[0] | 0},${c[1] | 0},${c[2] | 0},${a})`;
 
@@ -966,41 +998,9 @@ export class Renderer {
     return false;
   }
 
-  private labelLines(cfg: Config, ac: Aircraft): { text: string; kind: "title" | "sub" }[] {
-    const f = cfg.showFields;
-    const out: { text: string; kind: "title" | "sub" }[] = [];
-    const title = f.flight ? ac.flight ?? ac.hex.toUpperCase() : ac.airline;
-    if (title) out.push({ text: title, kind: "title" });
-
-    const sub: string[] = [];
-    if (f.type && (ac.typeName || ac.typeCode)) sub.push(ac.typeName ?? ac.typeCode!);
-    const alt = ac.altBaro ?? ac.altGeom;
-    if (f.altitude) {
-      if (ac.onGround) sub.push("GND");
-      else if (alt != null) sub.push(`${alt.toLocaleString("en-US")} ft`);
-    }
-    if (f.speed && ac.gs != null) sub.push(formatSpeed(ac.gs, cfg.speedUnit));
-    if (sub.length) out.push({ text: sub.join("   "), kind: "sub" });
-
-    if (f.destination && ac.destination && routePlausible(ac, cfg)) {
-      const head = ac.origin ? `${ac.origin} → ${ac.destination}` : `→ ${ac.destination}`;
-      out.push({ text: ac.destName ? `${head}   ${ac.destName}` : head, kind: "sub" });
-      if (cfg.showRouteDetail && ac.destLat != null && ac.destLon != null) {
-        const bits: string[] = [`${localTimeAt(ac.destLat, ac.destLon)} local`];
-        if (ac.lat != null && ac.lon != null) {
-          const mi = Math.round(greatCircleMiles(ac.lat, ac.lon, ac.destLat, ac.destLon));
-          if (mi > 1) bits.push(`${mi.toLocaleString("en-US")} mi to go`);
-        }
-        out.push({ text: bits.join("   ·   "), kind: "sub" });
-      }
-    }
-    if (f.registration && ac.registration) out.push({ text: ac.registration, kind: "sub" });
-    return out;
-  }
-
   private drawLabel(cfg: Config, v: Visible, strength: number): void {
     const ctx = this.ctx;
-    const lines = this.labelLines(cfg, v.tr.ac);
+    const lines = labelLines(cfg, v.tr.ac);
     if (!lines.length) return;
     const a = v.alpha * strength;
     if (a < 0.04) return;

--- a/web/src/styles/control.css
+++ b/web/src/styles/control.css
@@ -300,6 +300,51 @@ main {
   background: color-mix(in srgb, var(--accent) 22%, var(--panel-2));
 }
 
+/* Plane detail preview */
+.plane-preview {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 10px;
+  border-top: 1px solid var(--line);
+}
+.plane-preview .chips {
+  border-top: 0;
+  padding: 0 0 7px 0;
+}
+.plane-preview-title {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 8px 0;
+}
+.plane-preview-card {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 5px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg);
+}
+.plane-preview-card-row {
+  display: flex;
+  gap: 14px;
+}
+.plane-preview-card-row-title {
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 1.5px;
+  color: #f5f7ff;
+}
+.plane-preview-card-row-sub {
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.5px;
+  color: rgba(174, 182, 198, 1);
+}
+
 /* Palette */
 .palette {
   display: grid;


### PR DESCRIPTION
Export the `labelLines` function from `renderer.ts` and use it to render an example of the displayed plane information via a Plane Preview Card in the Control UI.

Before:
<img width="712" height="291" alt="image" src="https://github.com/user-attachments/assets/e57bf0e7-9f1d-4d2b-9ba4-9ff49fc5ae01" />

Now:
<img width="721" height="510" alt="image" src="https://github.com/user-attachments/assets/bd679500-282f-4605-b819-017915bfbedb" />
