### PR TITLE
Fix: Renderer: Plane Information: after drawing the title we need a to draw further down for the following line (due to the larger font size of the title)

### DIFF
--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -1006,6 +1006,7 @@ export class Renderer {
     if (a < 0.04) return;
 
     const { w, lh, h } = this.measureLabel(cfg, lines);
+
     const gap = cfg.glyphSizePx * 0.7 + 9;
     const onScreen = (b: { x: number; y: number; w: number; h: number }) =>
       b.x >= 6 && b.x + b.w <= this.w - 6 && b.y >= 6 && b.y + b.h <= this.h - 6;
@@ -1054,7 +1055,9 @@ export class Renderer {
       ctx.textBaseline = "top";
       ctx.shadowColor = "rgba(0,0,0,0.9)";
       ctx.shadowBlur = 6;
+
       let y = box.y;
+      let lastLineKind;
       for (const ln of lines) {
         if (ln.kind === "title") {
           ctx.font = `500 14px ${cfg.fonts.label}`;
@@ -1073,9 +1076,15 @@ export class Renderer {
             /* noop */
           }
         }
+
+        // after drawing the title we need a to draw further down for the following line (due to the larger font size of the title)
+        y += lastLineKind === "title" ? lh + 2 : lh;
+
         ctx.fillText(ln.text, box.x, y);
-        y += lh;
+
+        lastLineKind = ln.kind;
       }
+
       try {
         ctx.letterSpacing = "0px";
       } catch {


### PR DESCRIPTION
Only a 2px difference, but now it is correct:

Before:
<img width="422" height="292" alt="image" src="https://github.com/user-attachments/assets/34211a06-25d5-4d17-90a7-27157c176fee" />


Now:
<img width="431" height="251" alt="image" src="https://github.com/user-attachments/assets/8411714b-5513-477a-9e3a-83a448325269" />
