### PR TITLE
Add in-browser ambient mode (fullscreen + Screen Wake Lock) to the display

### DIFF
--- a/web/src/display/Display.tsx
+++ b/web/src/display/Display.tsx
@@ -2,18 +2,25 @@ import { useEffect, useRef } from "react";
 import type { Config, Theme } from "@shared/index.js";
 import { DEFAULT_CONFIG } from "@shared/index.js";
 import { useStream } from "../lib/useStream.js";
+import { useAmbientMode, kioskRequested } from "../lib/useAmbientMode.js";
 import { Renderer } from "./renderer.js";
 
 const THEMES: Theme[] = ["ambient", "telemetry", "focus"];
 
 export function Display() {
   const { state, conn } = useStream("display");
+  const ambient = useAmbientMode();
+  const isKiosk = kioskRequested();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rendererRef = useRef<Renderer | null>(null);
 
   // Keep the latest config in a ref so the RAF loop always reads fresh values.
   const configRef = useRef<Config>(state.config ?? DEFAULT_CONFIG);
   configRef.current = state.config ?? DEFAULT_CONFIG;
+
+  // Latest ambient toggle in a ref so the keydown listener stays subscribed once.
+  const ambientToggleRef = useRef(ambient.toggle);
+  ambientToggleRef.current = ambient.toggle;
 
   // Create renderer once.
   useEffect(() => {
@@ -72,6 +79,9 @@ export function Display() {
         case "h":
           conn.patchConfig({ showHud: !c.showHud });
           break;
+        case "f":
+          ambientToggleRef.current();
+          break;
       }
     };
     window.addEventListener("keydown", onKey);
@@ -93,6 +103,22 @@ export function Display() {
         </div>
       )}
       {!state.connected && <div className="reconnect">connecting…</div>}
+      {!isKiosk && (
+        <button
+          type="button"
+          className={`ambient-toggle ${ambient.active ? "on" : ""}`}
+          onClick={() => ambient.toggle()}
+          title={
+            ambient.active
+              ? "Exit ambient mode (fullscreen + keep awake) — press f"
+              : "Ambient mode: fullscreen + keep screen awake — press f"
+          }
+          aria-label="Toggle ambient fullscreen mode"
+        >
+          {ambient.active ? "◱ exit ambient" : "◳ ambient"}
+          {ambient.active && !ambient.wakeLocked && <span className="ambient-warn"> · no wake-lock</span>}
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/lib/useAmbientMode.ts
+++ b/web/src/lib/useAmbientMode.ts
@@ -1,0 +1,170 @@
+// Ambient mode: go fullscreen and hold a Screen Wake Lock so the display never
+// blanks — the in-browser equivalent of the Pi's Chromium kiosk, but it works
+// on any device (laptop, phone, smart TV). Degrades gracefully: if Wake Lock or
+// the Fullscreen API is missing (e.g. iOS Safari can't fullscreen a <div>), it
+// does whatever it can and never throws.
+//
+// `?kiosk=1` in the URL auto-engages on load (wake lock immediately; fullscreen
+// on the first user gesture, since browsers require one).
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Whether this URL requested kiosk/ambient mode (`?kiosk=1` or `?kiosk`). */
+export function kioskRequested(): boolean {
+  if (typeof window === "undefined") return false;
+  const v = new URLSearchParams(window.location.search).get("kiosk");
+  return v === "" || v === "1" || v === "true";
+}
+
+type FsElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+};
+type FsDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+};
+
+function fullscreenElement(): Element | null {
+  const d = document as FsDocument;
+  return document.fullscreenElement ?? d.webkitFullscreenElement ?? null;
+}
+
+async function requestFullscreen(): Promise<void> {
+  const el = document.documentElement as FsElement;
+  try {
+    if (el.requestFullscreen) await el.requestFullscreen();
+    else if (el.webkitRequestFullscreen) await el.webkitRequestFullscreen();
+  } catch {
+    // user gesture missing or unsupported (iOS) — wake lock still applies
+  }
+}
+
+async function exitFullscreen(): Promise<void> {
+  const d = document as FsDocument;
+  try {
+    if (document.exitFullscreen) await document.exitFullscreen();
+    else if (d.webkitExitFullscreen) await d.webkitExitFullscreen();
+  } catch {
+    /* already exited */
+  }
+}
+
+export interface AmbientMode {
+  /** Fullscreen and/or wake lock currently engaged. */
+  active: boolean;
+  /** True if the Screen Wake Lock is currently held. */
+  wakeLocked: boolean;
+  enter: () => Promise<void>;
+  exit: () => Promise<void>;
+  toggle: () => void;
+}
+
+export function useAmbientMode(): AmbientMode {
+  const [active, setActive] = useState(false);
+  const [wakeLocked, setWakeLocked] = useState(false);
+  // WakeLockSentinel isn't in every lib.dom; keep it loosely typed.
+  const sentinelRef = useRef<{ release: () => Promise<void>; addEventListener: (t: string, cb: () => void) => void } | null>(null);
+  // Whether the user wants the lock held — drives re-acquisition after the OS
+  // auto-releases the sentinel (tab hidden, device sleep).
+  const wantLockRef = useRef(false);
+
+  const acquireLock = useCallback(async () => {
+    const wl = (navigator as Navigator & { wakeLock?: { request: (t: "screen") => Promise<any> } }).wakeLock;
+    if (!wl) return;
+    try {
+      const s = await wl.request("screen");
+      sentinelRef.current = s;
+      setWakeLocked(true);
+      s.addEventListener("release", () => {
+        setWakeLocked(false);
+        sentinelRef.current = null;
+      });
+    } catch {
+      setWakeLocked(false);
+    }
+  }, []);
+
+  const releaseLock = useCallback(async () => {
+    const s = sentinelRef.current;
+    sentinelRef.current = null;
+    setWakeLocked(false);
+    if (s) {
+      try {
+        await s.release();
+      } catch {
+        /* noop */
+      }
+    }
+  }, []);
+
+  const enter = useCallback(async () => {
+    wantLockRef.current = true;
+    setActive(true);
+    await Promise.all([requestFullscreen(), acquireLock()]);
+  }, [acquireLock]);
+
+  const exit = useCallback(async () => {
+    wantLockRef.current = false;
+    setActive(false);
+    await Promise.all([exitFullscreen(), releaseLock()]);
+  }, [releaseLock]);
+
+  const toggle = useCallback(() => {
+    if (active) void exit();
+    else void enter();
+  }, [active, enter, exit]);
+
+  // Re-acquire the wake lock when the page becomes visible again — the browser
+  // silently releases it whenever the tab is hidden or the device sleeps.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && wantLockRef.current && !sentinelRef.current) {
+        void acquireLock();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [acquireLock]);
+
+  // Keep `active` in sync when the user leaves fullscreen via Esc / OS controls.
+  useEffect(() => {
+    const onFsChange = () => {
+      if (!fullscreenElement() && active) {
+        wantLockRef.current = false;
+        setActive(false);
+        void releaseLock();
+      }
+    };
+    document.addEventListener("fullscreenchange", onFsChange);
+    document.addEventListener("webkitfullscreenchange", onFsChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFsChange);
+      document.removeEventListener("webkitfullscreenchange", onFsChange);
+    };
+  }, [active, releaseLock]);
+
+  // `?kiosk=1`: grab the wake lock immediately; engage fullscreen on the first
+  // user gesture (browsers won't fullscreen without one).
+  useEffect(() => {
+    if (!kioskRequested()) return;
+    wantLockRef.current = true;
+    setActive(true);
+    void acquireLock();
+    const onGesture = () => {
+      void requestFullscreen();
+      window.removeEventListener("pointerdown", onGesture);
+      window.removeEventListener("keydown", onGesture);
+    };
+    window.addEventListener("pointerdown", onGesture);
+    window.addEventListener("keydown", onGesture);
+    return () => {
+      window.removeEventListener("pointerdown", onGesture);
+      window.removeEventListener("keydown", onGesture);
+    };
+  }, [acquireLock]);
+
+  // Release the lock if the component unmounts while held.
+  useEffect(() => () => void releaseLock(), [releaseLock]);
+
+  return { active, wakeLocked, enter, exit, toggle };
+}

--- a/web/src/styles/display.css
+++ b/web/src/styles/display.css
@@ -60,3 +60,29 @@ body,
   font: 12px "JetBrains Mono", ui-monospace, monospace;
   color: #6b7280;
 }
+.ambient-toggle {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  font: 12px "JetBrains Mono", ui-monospace, monospace;
+  color: #c9cdd6;
+  background: rgba(10, 12, 16, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.12; /* stay out of the way; reveal on hover */
+  transition: opacity 0.2s ease;
+}
+.ambient-toggle:hover,
+.ambient-toggle:focus-visible {
+  opacity: 0.9;
+  outline: none;
+}
+.ambient-toggle.on {
+  border-color: rgba(74, 222, 128, 0.5);
+  color: #4ade80;
+}
+.ambient-warn {
+  color: #e0a23d;
+}


### PR DESCRIPTION
## Summary

Adds an **ambient mode** to the display page: one tap (or the `f` key) puts it fullscreen and holds a **Screen Wake Lock** so the screen never blanks — the in-browser equivalent of the Raspberry Pi's Chromium kiosk, but it works on **any** device (laptop, phone, smart TV) with no OS/desktop configuration.

Today the always-on fullscreen behavior only exists on the Pi, via Chromium `--kiosk`/`--start-fullscreen` flags plus compositor tweaks in `pi-setup/setup-kiosk.sh`. This brings the same experience to anyone running the display in a normal browser, and is handy *on* the Pi too (`?kiosk=1`).

## What's included

- **`web/src/lib/useAmbientMode.ts`** (new) — a small, reusable hook that:
  - requests fullscreen (with Safari `webkit` fallbacks) and a screen wake lock
  - **re-acquires the wake lock** when the tab becomes visible again (browsers
    silently release it on hide/sleep)
  - **syncs state** when the user leaves fullscreen via Esc/OS controls
  - releases the lock on unmount
  - degrades gracefully: if Wake Lock or the Fullscreen API is unavailable
    (e.g. iOS Safari can't fullscreen a non-video element) it does whatever it
    can and never throws
- **`web/src/display/Display.tsx`** — three ways to engage it:
  1. an unobtrusive toggle button (bottom-left; near-invisible until hover,
     turns green when active)
  2. the **`f`** keyboard shortcut (matches the existing display shortcuts)
  3. the **`?kiosk=1`** URL param — auto-engages on load (wake lock immediately,
     fullscreen on first user gesture) and hides the toggle button
- **`web/src/styles/display.css`** — minimal styling for the toggle, in keeping
  with the pure-black ambient aesthetic.

## How to test

```bash
pnpm dev:web      # or: pnpm dev

- Open http://localhost:5173/, hover bottom-left, click "◳ ambient"
(or press f) → goes fullscreen and the screen stays awake.
- Open http://localhost:5173/?kiosk=1 → auto-engages with the button hidden.
- Press Esc to leave fullscreen → state resets and the lock is released.

Note: the wake lock only engages in a real browser over a secure context
(localhost counts); it won't appear in headless/automation. When the lock can't
be obtained the button shows a small "· no wake-lock" hint instead of failing.

Browser support

- Screen Wake Lock: Chrome/Edge, Android Chrome, Safari 16.4+.
- Fullscreen: all evergreen desktop browsers; iOS Safari can't fullscreen a
<div>, so there it holds the wake lock only — handled gracefully.

Notes

- Purely additive: no existing behavior changed, no new dependencies, no backend
changes. pnpm -F web typecheck passes.
- Complements (doesn't replace) the Pi kiosk setup.
```

### Demo


https://github.com/user-attachments/assets/96a75b49-bc41-46c6-92b7-a1f1cb038f83

