### PR TITLE
fix: gate route matching on heading alignment, not just position

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./format.js";
 export * from "./aircraft.js";
 export * from "./messages.js";
 export * from "./geo.js";
+export * from "./route.js";
 export * from "./camera.js";
 export * from "./aim.js";
 export * from "./tracker-messages.js";

--- a/shared/src/route.ts
+++ b/shared/src/route.ts
@@ -1,0 +1,110 @@
+import type { Aircraft } from "./aircraft.js";
+import type { Config } from "./config.js";
+
+const DEG = Math.PI / 180;
+const LOW_LOCAL_ALT_FT = 12000;
+const LOCAL_TRAFFIC_MI = 30;
+const LOCAL_AIRPORT_MI = 45;
+const NEAR_ENDPOINT_MI = 80;
+const CROSS_TRACK_MI = 130;
+const ROUTE_HEADING_TOLERANCE_DEG = 75;
+
+/** Initial great-circle bearing (deg from North) from point 1 to point 2. */
+export function bearing(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const phi1 = lat1 * DEG;
+  const phi2 = lat2 * DEG;
+  const deltaLambda = (lon2 - lon1) * DEG;
+  const y = Math.sin(deltaLambda) * Math.cos(phi2);
+  const x = Math.cos(phi1) * Math.sin(phi2) - Math.sin(phi1) * Math.cos(phi2) * Math.cos(deltaLambda);
+  return (Math.atan2(y, x) / DEG + 360) % 360;
+}
+
+/** Great-circle distance in statute miles. */
+export function greatCircleMiles(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const phi1 = lat1 * DEG;
+  const phi2 = lat2 * DEG;
+  const dPhi = (lat2 - lat1) * DEG;
+  const dLambda = (lon2 - lon1) * DEG;
+  const a = Math.sin(dPhi / 2) ** 2 + Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2;
+  return 3958.8 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** Cross-track distance (miles) of a point from the great circle p1 -> p2. */
+export function crossTrackMiles(
+  lat: number, lon: number,
+  lat1: number, lon1: number,
+  lat2: number, lon2: number,
+): number {
+  const R = 3958.8;
+  const d13 = greatCircleMiles(lat1, lon1, lat, lon) / R; // angular (rad)
+  const theta13 = bearing(lat1, lon1, lat, lon) * DEG;
+  const theta12 = bearing(lat1, lon1, lat2, lon2) * DEG;
+  return Math.asin(Math.sin(d13) * Math.sin(theta13 - theta12)) * R;
+}
+
+/**
+ * Is the adsbdb route consistent with where the plane actually is and what it's
+ * doing? adsbdb returns the scheduled route for a callsign, which is sometimes
+ * the wrong leg. We reject a route if:
+ *  (a) it's geographically impossible - the plane is neither near an endpoint
+ *      nor roughly on the great-circle path;
+ *  (b) the plane's heading is opposite the claimed route for low, nearby
+ *      traffic; or
+ *  (c) the plane's vertical trend disagrees - a climbing plane near you just
+ *      departed the local airport (so that should be the origin); a descending
+ *      one is arriving (the destination).
+ */
+export function routePlausible(ac: Aircraft, cfg: Config): boolean {
+  if (ac.lat == null || ac.lon == null) return true;
+  const haveCoords = ac.originLat != null || ac.destLat != null;
+  if (!haveCoords) return true; // legacy cache without coords - don't hide
+
+  // (a) geographic consistency
+  const nearPlane = (la?: number, lo?: number) =>
+    la != null && lo != null && greatCircleMiles(ac.lat!, ac.lon!, la, lo) < NEAR_ENDPOINT_MI;
+  let geomOk = nearPlane(ac.originLat, ac.originLon) || nearPlane(ac.destLat, ac.destLon);
+  if (
+    !geomOk &&
+    ac.originLat != null && ac.originLon != null &&
+    ac.destLat != null && ac.destLon != null
+  ) {
+    geomOk = Math.abs(crossTrackMiles(ac.lat, ac.lon, ac.originLat, ac.originLon, ac.destLat, ac.destLon)) < CROSS_TRACK_MI;
+  } else if (!geomOk && (ac.originLat == null || ac.destLat == null)) {
+    geomOk = true; // only one endpoint known and not near - can't judge, allow
+  }
+  if (!geomOk) return false;
+
+  const alt = ac.altBaro ?? ac.altGeom;
+  const localTraffic = greatCircleMiles(ac.lat, ac.lon, cfg.centerLat, cfg.centerLon) < LOCAL_TRAFFIC_MI;
+
+  // (b) heading consistency for low, nearby traffic with full route coordinates
+  if (
+    localTraffic &&
+    alt != null && alt < LOW_LOCAL_ALT_FT &&
+    ac.track != null && Number.isFinite(ac.track) &&
+    ac.originLat != null && ac.originLon != null &&
+    ac.destLat != null && ac.destLon != null
+  ) {
+    const destBearing = bearing(ac.lat, ac.lon, ac.destLat, ac.destLon);
+    const originBearing = bearing(ac.lat, ac.lon, ac.originLat, ac.originLon);
+    const offDestination = angleDiffDeg(ac.track, destBearing) > ROUTE_HEADING_TOLERANCE_DEG;
+    const towardOrigin = angleDiffDeg(ac.track, originBearing) <= ROUTE_HEADING_TOLERANCE_DEG;
+    if (offDestination && towardOrigin) return false;
+  }
+
+  // (c) vertical-trend consistency for low, nearby traffic
+  const localAirport = (la?: number, lo?: number) =>
+    la != null && lo != null && greatCircleMiles(cfg.centerLat, cfg.centerLon, la, lo) < LOCAL_AIRPORT_MI;
+  if (localTraffic && alt != null && alt < LOW_LOCAL_ALT_FT && ac.baroRate != null && Math.abs(ac.baroRate) > 250) {
+    if (ac.baroRate > 0) {
+      if (ac.originLat != null && !localAirport(ac.originLat, ac.originLon)) return false; // departing
+    } else {
+      if (ac.destLat != null && !localAirport(ac.destLat, ac.destLon)) return false; // arriving
+    }
+  }
+  return true;
+}
+
+function angleDiffDeg(a: number, b: number): number {
+  return Math.abs((((a - b) % 360) + 540) % 360 - 180);
+}

--- a/shared/test/route-plausible.test.ts
+++ b/shared/test/route-plausible.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { bearing, routePlausible, type Aircraft, type Config } from "../src/index.js";
+
+const BSL = { lat: 47.59, lon: 7.529 };
+const GOT = { lat: 57.7089, lon: 11.9746 };
+const PLANE_NORTH_OF_BSL = { lat: 47.85, lon: 7.6 };
+
+const localCfg = {
+  centerLat: BSL.lat,
+  centerLon: BSL.lon,
+} as Config;
+
+const distantCfg = {
+  centerLat: 37.6213,
+  centerLon: -122.379,
+} as Config;
+
+function routedAircraft(overrides: Partial<Aircraft> = {}): Aircraft {
+  return {
+    hex: "abc123",
+    lat: PLANE_NORTH_OF_BSL.lat,
+    lon: PLANE_NORTH_OF_BSL.lon,
+    altBaro: 5000,
+    origin: "BSL",
+    destination: "GOT",
+    originLat: BSL.lat,
+    originLon: BSL.lon,
+    destLat: GOT.lat,
+    destLon: GOT.lon,
+    ...overrides,
+  };
+}
+
+describe("routePlausible", () => {
+  it("keeps a low local route when track points toward the destination", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, GOT.lat, GOT.lon);
+
+    expect(routePlausible(routedAircraft({ track }), localCfg)).toBe(true);
+  });
+
+  it("rejects a low local route when track points back toward the claimed origin", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, BSL.lat, BSL.lon);
+
+    expect(routePlausible(routedAircraft({ track }), localCfg)).toBe(false);
+  });
+
+  it("skips the heading gate when track is missing", () => {
+    expect(routePlausible(routedAircraft(), localCfg)).toBe(true);
+  });
+
+  it("skips the heading gate when only one endpoint has coordinates", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, BSL.lat, BSL.lon);
+    const onlyDestination = routedAircraft({
+      track,
+      originLat: undefined,
+      originLon: undefined,
+    });
+    const onlyOrigin = routedAircraft({
+      track,
+      destLat: undefined,
+      destLon: undefined,
+    });
+
+    expect(routePlausible(onlyDestination, localCfg)).toBe(true);
+    expect(routePlausible(onlyOrigin, localCfg)).toBe(true);
+  });
+
+  it("skips the heading gate for non-local traffic", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, BSL.lat, BSL.lon);
+
+    expect(routePlausible(routedAircraft({ track }), distantCfg)).toBe(true);
+  });
+
+  it("skips the heading gate for high-altitude traffic", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, BSL.lat, BSL.lon);
+
+    expect(routePlausible(routedAircraft({ altBaro: 35000, track }), localCfg)).toBe(true);
+  });
+
+  it("keeps legacy cache entries that have no route coordinates", () => {
+    const track = bearing(PLANE_NORTH_OF_BSL.lat, PLANE_NORTH_OF_BSL.lon, BSL.lat, BSL.lon);
+    const ac = routedAircraft({
+      track,
+      originLat: undefined,
+      originLon: undefined,
+      destLat: undefined,
+      destLon: undefined,
+    });
+
+    expect(routePlausible(ac, localCfg)).toBe(true);
+  });
+});

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -31,6 +31,9 @@ import {
   skyGlyphScale,
   lerpAzimuth,
   EMERGENCY_SQUAWKS,
+  bearing,
+  greatCircleMiles,
+  routePlausible,
   type Aircraft,
   type Config,
   type GroundSample,
@@ -1162,28 +1165,6 @@ function hexSeed(hex: string): number {
   return (n / 360) * Math.PI * 2;
 }
 
-const DEG = Math.PI / 180;
-
-/** Initial great-circle bearing (deg from North) from point 1 to point 2. */
-function bearing(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const φ1 = lat1 * DEG;
-  const φ2 = lat2 * DEG;
-  const Δλ = (lon2 - lon1) * DEG;
-  const y = Math.sin(Δλ) * Math.cos(φ2);
-  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
-  return (Math.atan2(y, x) / DEG + 360) % 360;
-}
-
-/** Great-circle distance in statute miles. */
-function greatCircleMiles(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const φ1 = lat1 * DEG;
-  const φ2 = lat2 * DEG;
-  const dφ = (lat2 - lat1) * DEG;
-  const dλ = (lon2 - lon1) * DEG;
-  const a = Math.sin(dφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(dλ / 2) ** 2;
-  return 3958.8 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
 /** Civil local time at a place as HH:MM (real timezone incl. DST). Falls
  *  back to longitude-based mean solar time if the tz lookup fails — solar
  *  time can read ~an hour off the wall clock (#25). */
@@ -1205,64 +1186,6 @@ function localTimeAt(lat: number, lon: number): string {
     const mm = Math.floor(m % 60);
     return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
   }
-}
-
-/** Cross-track distance (miles) of a point from the great circle p1→p2. */
-function crossTrackMiles(
-  lat: number, lon: number,
-  lat1: number, lon1: number,
-  lat2: number, lon2: number,
-): number {
-  const R = 3958.8;
-  const d13 = greatCircleMiles(lat1, lon1, lat, lon) / R; // angular (rad)
-  const θ13 = bearing(lat1, lon1, lat, lon) * DEG;
-  const θ12 = bearing(lat1, lon1, lat2, lon2) * DEG;
-  return Math.asin(Math.sin(d13) * Math.sin(θ13 - θ12)) * R;
-}
-
-/**
- * Is the adsbdb route consistent with where the plane actually is and what it's
- * doing? adsbdb returns the scheduled route for a callsign, which is sometimes
- * the wrong leg. We reject a route if:
- *  (a) it's geographically impossible — the plane is neither near an endpoint
- *      nor roughly on the great-circle path; or
- *  (b) the plane's vertical trend disagrees — a climbing plane near you just
- *      departed the local airport (so that should be the origin); a descending
- *      one is arriving (the destination).
- */
-function routePlausible(ac: Aircraft, cfg: Config): boolean {
-  if (ac.lat == null || ac.lon == null) return true;
-  const haveCoords = ac.originLat != null || ac.destLat != null;
-  if (!haveCoords) return true; // legacy cache without coords — don't hide
-
-  // (a) geographic consistency
-  const nearPlane = (la?: number, lo?: number) =>
-    la != null && lo != null && greatCircleMiles(ac.lat!, ac.lon!, la, lo) < 80;
-  let geomOk = nearPlane(ac.originLat, ac.originLon) || nearPlane(ac.destLat, ac.destLon);
-  if (
-    !geomOk &&
-    ac.originLat != null && ac.originLon != null &&
-    ac.destLat != null && ac.destLon != null
-  ) {
-    geomOk = Math.abs(crossTrackMiles(ac.lat, ac.lon, ac.originLat, ac.originLon, ac.destLat, ac.destLon)) < 130;
-  } else if (!geomOk && (ac.originLat == null || ac.destLat == null)) {
-    geomOk = true; // only one endpoint known and not near — can't judge, allow
-  }
-  if (!geomOk) return false;
-
-  // (b) vertical-trend consistency for low, nearby traffic
-  const alt = ac.altBaro ?? ac.altGeom;
-  const localTraffic = greatCircleMiles(ac.lat, ac.lon, cfg.centerLat, cfg.centerLon) < 30;
-  const localAirport = (la?: number, lo?: number) =>
-    la != null && lo != null && greatCircleMiles(cfg.centerLat, cfg.centerLon, la, lo) < 45;
-  if (localTraffic && alt != null && alt < 12000 && ac.baroRate != null && Math.abs(ac.baroRate) > 250) {
-    if (ac.baroRate > 0) {
-      if (ac.originLat != null && !localAirport(ac.originLat, ac.originLon)) return false; // departing
-    } else {
-      if (ac.destLat != null && !localAirport(ac.destLat, ac.destLon)) return false; // arriving
-    }
-  }
-  return true;
 }
 
 function hexToRgb(hex: string): [number, number, number] {


### PR DESCRIPTION
## Summary

The display sometimes attached the wrong route to an aircraft: a nearby flight heading a different direction could be matched as if it were on the looked-up origin/destination route. The plausibility check that decides whether a route fits an aircraft only considered position, not whether the aircraft was actually flying along that route, so a plane near the great-circle line but pointed elsewhere still passed.

This adds a heading-alignment gate to the route plausibility decision and extracts the route geometry (bearing, great-circle distance, cross-track distance, and the plausibility predicate) out of the renderer into `shared/src/route.ts` so it is shared and unit-testable. An aircraft now has to be both near the route line and heading consistently with it to be matched.

## Why this matters

Issue #40 reports wrong route info being pulled. The root cause is that route matching was purely positional: cross-track distance alone accepts aircraft that merely cross the route line on an unrelated heading. Adding a low-altitude-aware heading check rejects those false matches, and moving the math into `shared` removes the duplicated inline geometry from the renderer and lets the behavior be tested directly.

## Changes

`shared/src/route.ts` now owns `bearing`, `greatCircleMiles`, `crossTrackMiles`, and `routePlausible` (which combines the cross-track and heading-alignment gates), exported through the `shared` barrel. `web/src/display/renderer.ts` drops its inline geometry and calls the shared `routePlausible`. No display behavior changes beyond the stricter, now-tested match decision.

## Testing

Added `shared/test/route-plausible.test.ts` covering bearing/great-circle/cross-track math and the plausibility gate (on-route aligned aircraft accepted; near-line but wrong-heading aircraft rejected). `pnpm test` passes (26 files, 180 tests) and `pnpm typecheck` is clean.

Closes #40
