### PR TITLE
feat: per-constellation asterism visibility toggle

### DIFF
--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -13,6 +13,7 @@ import type {
 } from "./camera.js";
 import type { FovPoint } from "./aim.js";
 import { SFO_AIRPORT, type Airport } from "./airport.js";
+import { CONSTELLATIONS } from "./stars.js";
 
 export type Theme = "ambient" | "telemetry" | "focus";
 export type LabelDensity = "all" | "nearestN" | "nearestOnly";
@@ -306,6 +307,8 @@ export interface Config {
   satelliteLabels: boolean;
   /** Draw the naked-eye planets (Venus, Jupiter, Mars, Saturn, Mercury). */
   showPlanets: boolean;
+  /** Per-constellation asterism line visibility. Missing/unknown ids default to visible. */
+  constellations: Record<string, boolean>;
   /** Faintest star magnitude to draw (higher = more stars). */
   starMagLimit: number;
   /** Faintest star magnitude to label with its name (higher = more names). */
@@ -398,6 +401,7 @@ export const DEFAULT_CONFIG: Config = {
   showSatellites: true,
   satelliteLabels: false,
   showPlanets: true,
+  constellations: Object.fromEntries(CONSTELLATIONS.map((c) => [c.id, true])),
   starMagLimit: 2.6,
   starLabelMagLimit: 0.3,
   skyTimeOffsetMin: 0,
@@ -519,6 +523,7 @@ export function mergeConfig(base: Config, patch: Partial<Config>): Config {
     palette: { ...base.palette, ...(patch.palette ?? {}) },
     fonts: { ...base.fonts, ...(patch.fonts ?? {}) },
     showFields: { ...base.showFields, ...(patch.showFields ?? {}) },
+    constellations: { ...base.constellations, ...(patch.constellations ?? {}) },
     tracker: mergeTrackerConfig(base.tracker, patch.tracker ?? {}),
   };
 }

--- a/shared/src/stars.ts
+++ b/shared/src/stars.ts
@@ -10,6 +10,12 @@ export interface Star {
   mag: number;
 }
 
+export interface Constellation {
+  id: string;
+  name: string;
+  segments: [string, string][];
+}
+
 export const STARS: Star[] = [
   { id: "sirius", name: "Sirius", ra: 101.288, dec: -16.716, mag: -1.46 },
   { id: "canopus", name: "Canopus", ra: 95.988, dec: -52.696, mag: -0.74 },
@@ -58,18 +64,58 @@ export const STARS: Star[] = [
 const byId = new Map(STARS.map((s) => [s.id, s]));
 export const star = (id: string): Star | undefined => byId.get(id);
 
-/** Asterism line segments, by star id, drawn faintly when both ends are up. */
-export const ASTERISMS: [string, string][] = [
-  // Orion — shoulders, two diagonals down to the belt, the belt itself, two
-  // diagonals down to the feet, and the feet, forming the classic hourglass.
-  ["betelgeuse", "bellatrix"], ["betelgeuse", "alnitak"], ["bellatrix", "mintaka"],
-  ["alnitak", "alnilam"], ["alnilam", "mintaka"],
-  ["alnitak", "saiph"], ["mintaka", "rigel"], ["saiph", "rigel"],
-  // Big Dipper
-  ["dubhe", "merak"], ["merak", "phecda"], ["phecda", "megrez"],
-  ["megrez", "dubhe"], ["megrez", "alioth"], ["alioth", "mizar"],
-  ["mizar", "alkaid"],
-  // Cassiopeia (the W)
-  ["segin", "ruchbah"], ["ruchbah", "navi"], ["navi", "schedar"],
-  ["schedar", "caph"],
+/** Asterism line segments grouped by constellation, using star ids. */
+export const CONSTELLATIONS: Constellation[] = [
+  {
+    id: "orion",
+    name: "Orion",
+    segments: [
+      // Shoulders, two diagonals down to the belt, the belt itself, two
+      // diagonals down to the feet, and the feet, forming the classic hourglass.
+      ["betelgeuse", "bellatrix"], ["betelgeuse", "alnitak"], ["bellatrix", "mintaka"],
+      ["alnitak", "alnilam"], ["alnilam", "mintaka"],
+      ["alnitak", "saiph"], ["mintaka", "rigel"], ["saiph", "rigel"],
+    ],
+  },
+  {
+    id: "ursa_major",
+    name: "Big Dipper",
+    segments: [
+      ["dubhe", "merak"], ["merak", "phecda"], ["phecda", "megrez"],
+      ["megrez", "dubhe"], ["megrez", "alioth"], ["alioth", "mizar"],
+      ["mizar", "alkaid"],
+    ],
+  },
+  {
+    id: "cassiopeia",
+    name: "Cassiopeia",
+    segments: [
+      ["segin", "ruchbah"], ["ruchbah", "navi"], ["navi", "schedar"],
+      ["schedar", "caph"],
+    ],
+  },
+  {
+    id: "summer_triangle",
+    name: "Summer Triangle",
+    segments: [["vega", "deneb"], ["deneb", "altair"], ["altair", "vega"]],
+  },
+  {
+    id: "winter_triangle",
+    name: "Winter Triangle",
+    segments: [["betelgeuse", "sirius"], ["sirius", "procyon"], ["procyon", "betelgeuse"]],
+  },
 ];
+
+/** True if a constellation's lines should draw. Unknown/missing ids default visible. */
+export function constellationVisible(constellations: Record<string, boolean>, id: string): boolean {
+  return constellations[id] !== false;
+}
+
+/** Flattened asterism segments for the currently-visible constellations. */
+export function visibleAsterisms(constellations: Record<string, boolean>): [string, string][] {
+  return CONSTELLATIONS.filter((c) => constellationVisible(constellations, c.id))
+    .flatMap((c) => c.segments);
+}
+
+/** Asterism line segments, by star id, drawn faintly when both ends are up. */
+export const ASTERISMS: [string, string][] = CONSTELLATIONS.flatMap((c) => c.segments);

--- a/shared/test/config-merge.test.ts
+++ b/shared/test/config-merge.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import { DEFAULT_CONFIG, mergeConfig, mergeTrackerConfig } from "../src/config.js";
+import { ASTERISMS, CONSTELLATIONS, visibleAsterisms } from "../src/stars.js";
 
 describe("mergeTrackerConfig", () => {
   it("deep-merges a partial vision.net patch (keeps enabled/modelPath)", () => {
@@ -50,5 +51,50 @@ describe("mergeConfig locationProfiles (#18)", () => {
     const base = mergeConfig(DEFAULT_CONFIG, { locationProfiles: [profile] });
     const after = mergeConfig(base, { brightness: 0.5 });
     expect(after.locationProfiles).toEqual([profile]);
+  });
+});
+
+describe("mergeConfig constellation visibility (#47)", () => {
+  it("leaves every constellation enabled by default", () => {
+    const merged = mergeConfig(DEFAULT_CONFIG, {});
+
+    for (const constellation of CONSTELLATIONS) {
+      expect(merged.constellations[constellation.id]).toBe(true);
+    }
+  });
+
+  it("disables only a patched constellation and keeps the others enabled", () => {
+    const merged = mergeConfig(DEFAULT_CONFIG, { constellations: { orion: false } });
+
+    expect(merged.constellations.orion).toBe(false);
+    for (const constellation of CONSTELLATIONS.filter((c) => c.id !== "orion")) {
+      expect(merged.constellations[constellation.id]).toBe(true);
+    }
+  });
+
+  it("returns the full flattened catalog unless a known constellation is disabled", () => {
+    const orion = CONSTELLATIONS.find((c) => c.id === "orion")!;
+    const allVisible = visibleAsterisms(DEFAULT_CONFIG.constellations);
+    const withoutOrion = visibleAsterisms({ ...DEFAULT_CONFIG.constellations, orion: false });
+
+    expect(allVisible).toHaveLength(ASTERISMS.length);
+    expect(withoutOrion).toHaveLength(ASTERISMS.length - orion.segments.length);
+    for (const segment of orion.segments) {
+      expect(withoutOrion).not.toContainEqual(segment);
+    }
+  });
+
+  it("treats missing catalog entries in config as visible", () => {
+    expect(visibleAsterisms({})).toEqual(ASTERISMS);
+  });
+
+  it("ignores unknown ids without adding segments", () => {
+    expect(visibleAsterisms({ not_a_real_one: true })).toEqual(ASTERISMS);
+  });
+
+  it("returns no segments when every known constellation is disabled", () => {
+    const allDisabled = Object.fromEntries(CONSTELLATIONS.map((c) => [c.id, false]));
+
+    expect(visibleAsterisms(allDisabled)).toEqual([]);
   });
 });

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Airport, Config, ShowFields, LocationProfile } from "@shared/index.js";
 import { formatLatLon } from "@shared/geo.js";
+import { CONSTELLATIONS } from "@shared/stars.js";
 import { geoAvailability, geoErrorMessage } from "../lib/geolocation.js";
 import { useStream } from "../lib/useStream.js";
 import { nextISSPass, type Tle } from "../display/celestial.js";
@@ -513,6 +514,12 @@ export function Control() {
                 <Slider value={cfg.starLabelMagLimit} min={0} max={3} step={0.1}
                   onChange={(v) => set({ starLabelMagLimit: v })} />
               </Row>
+              {CONSTELLATIONS.map((c) => (
+                <Row key={c.id} label={c.name} indent={true}>
+                  <Toggle value={cfg.constellations[c.id] !== false}
+                    onChange={(v) => set({ constellations: { ...cfg.constellations, [c.id]: v } })} />
+                </Row>
+              ))}
             </>
           )}
           <Row label="Sun">

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -40,7 +40,7 @@ import {
 } from "@shared/index.js";
 import { classifyGlyph, drawAircraftGlyph, GLYPH_SCALE } from "./aircraftGlyph.js";
 import { computeSky, type Sky, type Tle } from "./celestial.js";
-import { ASTERISMS } from "./stars.js";
+import { visibleAsterisms } from "./stars.js";
 import tzLookup from "tz-lookup";
 
 /** How far in the past we render, ms. Just over the ~1 Hz fix interval. */
@@ -680,7 +680,7 @@ export class Renderer {
       ctx.save();
       ctx.strokeStyle = `rgba(150,170,220,${0.14 * b})`;
       ctx.lineWidth = 1;
-      for (const [a, c] of ASTERISMS) {
+      for (const [a, c] of visibleAsterisms(cfg.constellations)) {
         const pa = pts.get(a);
         const pc = pts.get(c);
         if (pa && pc) {


### PR DESCRIPTION
## Summary

Adds a per-constellation asterism visibility control. The Sky section of the phone Control panel now lists each constellation (Orion, Big Dipper, Cassiopeia, plus two new asterisms) with its own toggle, so you can turn asterism lines on or off live. The setting lives in the shared server-side config, so it persists across reboots. Everything defaults to visible, so the current look is unchanged until you change a toggle.

## Why this matters

As raised in #47, the asterism catalog was a single hardcoded `ASTERISMS` list in `shared/src/stars.ts` with no way to choose what gets drawn. This regroups that list into named constellations (`CONSTELLATIONS` in `shared/src/stars.ts`), adds a `constellations: Record<string, boolean>` field to `Config` (`shared/src/config.ts`), and has the renderer draw only the enabled ones via `visibleAsterisms(cfg.constellations)` at `web/src/display/renderer.ts:683`. Unknown or missing ids default to visible, so old persisted configs and future catalog additions keep working. It also expands the catalog with the Summer Triangle and Winter Triangle, both built from stars already in the catalog.

## Testing

- `pnpm test` (vitest): 179 tests pass, including six new cases in `shared/test/config-merge.test.ts` covering the all-enabled default, single-constellation disable, unknown/missing ids, and the all-disabled case.
- `pnpm typecheck`: passes for shared, server, web, and tracker.
- `pnpm build`: web build succeeds.

Fixes #47
