### PR TITLE
Add Planetarium mode

### DIFF
--- a/server/src/datasource.ts
+++ b/server/src/datasource.ts
@@ -277,6 +277,20 @@ export class Poller {
 
   private async tick(): Promise<void> {
     const now = Date.now();
+
+    if (this.o.getConfig().planetariumMode) {
+      this.last = [];
+      this.o.onSnapshot(now, []);
+      this.o.onStatus({
+        source: this.o.source,
+        ok: true,
+        count: 0,
+        lastOk: now,
+        message: "Aircraft display disabled",
+      });
+    return;
+    }
+ 
     if (this.o.source === "api" && now < this.apiBackoffUntil) {
       const waitS = Math.ceil((this.apiBackoffUntil - now) / 1000);
       this.status = {

--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -203,8 +203,7 @@ export interface TrackerConfig {
       everyNTicks: number;
     };
   };
-  /** Planetarium mode - don't show any planes */
-  planetariumMode: boolean;
+
   /** Idle "ready position" when auto mode has no target. */
   home: {
     enabled: boolean;
@@ -299,7 +298,9 @@ export interface Config {
   /** Show the on-screen calibration HUD on the display. */
   showHud: boolean;
 
-  // --- sky layer (sun / moon / stars / satellites at true positions) ---
+  /** Planetarium mode - don't show any planes */
+  planetariumMode: boolean;
+  // --- sky layer (sun / moon / stars / satellites at true positions) ---  
   showStars: boolean;
   showSun: boolean;
   showMoon: boolean;
@@ -394,6 +395,7 @@ export const DEFAULT_CONFIG: Config = {
   airport: SFO_AIRPORT,
   showHud: false,
 
+  planetariumMode: false,
   showStars: true,
   showSun: true,
   showMoon: true,

--- a/shared/src/config.ts
+++ b/shared/src/config.ts
@@ -203,6 +203,8 @@ export interface TrackerConfig {
       everyNTicks: number;
     };
   };
+  /** Planetarium mode - don't show any planes */
+  planetariumMode: boolean;
   /** Idle "ready position" when auto mode has no target. */
   home: {
     enabled: boolean;

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -180,7 +180,7 @@ export function Control() {
       { enableHighAccuracy: true, timeout: 15000, maximumAge: 60_000 },
     );
   };
-  const planetariumMode = cfg.planetariumMode;
+
   // plane preview card
   const planePreview = labelLines(
     cfg,

--- a/web/src/control/Control.tsx
+++ b/web/src/control/Control.tsx
@@ -180,7 +180,7 @@ export function Control() {
       { enableHighAccuracy: true, timeout: 15000, maximumAge: 60_000 },
     );
   };
-
+  const planetariumMode = cfg.planetariumMode;
   // plane preview card
   const planePreview = labelLines(
     cfg,
@@ -500,6 +500,10 @@ export function Control() {
         </Section>
 
         <Section title="Sky">
+          <Row label="Planetarium mode" hint="Only show stars etc. - no planes">
+            <Toggle value={cfg.planetariumMode} onChange={(v) => set({ planetariumMode: v })} />
+          </Row>
+ 
           <Row label="Stars">
             <Toggle value={cfg.showStars} onChange={(v) => set({ showStars: v })} />
           </Row>


### PR DESCRIPTION
Add a new "Planetarium mode" so that the system can be quickly switched to display just the celestial bodies.

- Added a new boolean into the config and control
- Added a fast-exit to tick() if planetarium mode is set.

fixes https://github.com/cpaczek/skylight/issues/60