### PR TITLE
fix: correct AIRCRAFT_JSON_URL default and implement verticalRate display

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ geometry - turn off **Airport runways** if you've moved, or replace it in
 | Env | Default | Meaning |
 |---|---|---|
 | `DATA_SOURCE` | `radio` | `radio` (dump1090) or `api` (airplanes.live) |
-| `AIRCRAFT_JSON_URL` | `http://localhost:8080/aircraft.json` | dump1090 feed |
+| `AIRCRAFT_JSON_URL` | `http://localhost:8080/data/aircraft.json` | dump1090 feed |
 | `SUPPLEMENT_API` | `1` | When on radio, merge the API too (keeps landing aircraft alive) |
 | `PORT` / `HOST` | `3000` / `0.0.0.0` | HTTP + WebSocket |
 | `ALLOWED_HOSTS` | *(empty)* | Extra Host/Origin allowlist entries, comma-separated. Wildcards: `*.example.com`. Loopback, RFC1918 LAN, IPv6 ULA / link-local, and `*.local` are allowed by default. |

--- a/pi-setup/README.md
+++ b/pi-setup/README.md
@@ -52,7 +52,7 @@ LAT=37.6213 LON=-122.379 ./pi-setup/install-on-pi.sh            # set your coord
 
 Installs the rtl-sdr-blog V4 driver (+ DVB-T blacklist), dump1090-fa, Node + pnpm,
 builds the app, and enables the `skylight-server` service. **Verify decode first** with
-`rtl_test -t` and `curl -s localhost:8080/aircraft.json | head` before moving on.
+`rtl_test -t` and `curl -s localhost:8080/data/aircraft.json | head` before moving on.
 
 ## 3. Kiosk display - on the Pi
 

--- a/pi-setup/install-on-pi.sh
+++ b/pi-setup/install-on-pi.sh
@@ -122,6 +122,6 @@ echo
 echo "Done."
 echo "  Display : http://localhost:3000/  (point Chromium kiosk here — see setup-kiosk.sh)"
 echo "  Control : http://$IP:3000/control  (open on your phone)"
-echo "  Decoder : http://$IP:8080/aircraft.json  (raw decoded feed)"
+echo "  Decoder : http://$IP:8080/data/aircraft.json  (raw decoded feed)"
 echo
 echo "Verify decode first:  rtl_test -t   then   curl -s localhost:8080/data/aircraft.json | head"

--- a/pi-setup/skylight-server.service
+++ b/pi-setup/skylight-server.service
@@ -13,7 +13,7 @@ Environment=NODE_ENV=production
 Environment=PORT=3000
 Environment=HOST=0.0.0.0
 Environment=DATA_SOURCE=radio
-Environment=AIRCRAFT_JSON_URL=http://localhost:8080/aircraft.json
+Environment=AIRCRAFT_JSON_URL=http://localhost:8080/data/aircraft.json
 ExecStart=__PNPM__ -F server start
 Restart=always
 RestartSec=3

--- a/web/src/display/renderer.ts
+++ b/web/src/display/renderer.ts
@@ -156,6 +156,10 @@ export function labelLines(cfg: Config, ac: Aircraft): { text: string; kind: "ti
     else if (alt != null) sub.push(formatAltitude(alt, cfg.altitudeUnit));
   }
   if (f.speed && ac.gs != null) sub.push(formatSpeed(ac.gs, cfg.speedUnit));
+  if (f.verticalRate && ac.baroRate != null) {
+    const sign = ac.baroRate > 0 ? "+" : "";
+    sub.push(`${sign}${ac.baroRate} fpm`);
+  }
   if (sub.length) out.push({ text: sub.join("   "), kind: "sub" });
 
   if (f.destination && ac.destination && routePlausible(ac, cfg)) {


### PR DESCRIPTION
- Fix AIRCRAFT_JSON_URL default from /aircraft.json to /data/aircraft.json in README, pi-setup service, install script, and pi-setup README
- Implement verticalRate display in labelLines() renderer — the showFields.verticalRate toggle existed in config and control panel but had no effect